### PR TITLE
change to default geo-ip lookup service

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -21,7 +21,7 @@ const config = {
     'pass': 'Explorer!1'
   },
   'freegeoip': {
-    'api': 'http://freegeoip.net/json/'
+    'api': 'https://extreme-ip-lookup.com/json/'
   },
   'rpc': {
     'host': '127.0.0.1',


### PR DESCRIPTION
Fixes #
- Fix geo ip address lookup, old service changed to require api token
