### PR TITLE
CVE-2018-14732 Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "style-loader": "^0.20.1",
     "uglifyjs-webpack-plugin": "^1.2.4",
     "webpack": "^3.11.0",
-    "webpack-dev-server": "^2.11.1",
+    "webpack-dev-server": ">=3.1.11",
     "worker-loader": "^1.1.1"
   }
 }


### PR DESCRIPTION
Fixes #
CVE-2018-14732 

<img width="726" alt="Screen Shot 2019-03-15 at 2 31 34 PM" src="https://user-images.githubusercontent.com/25401217/54428600-100f8b80-472f-11e9-82e3-3496a1c8c40b.png">
An issue was discovered in lib/Server.js in webpack-dev-server before 3.1.11. Attackers are able to steal developer's code because the origin of requests is not checked by the WebSocket server, which is used for HMR (Hot Module Replacement). Anyone can receive the HMR message sent by the WebSocket server via a ws://127.0.0.1:8080/ connection from any origin.
## Proposed Changes
- Update webpack-dev-server

