### PR TITLE
'nonstandard' vout will no longer be stored in db

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+* text eol=lf

--- a/cron/util.js
+++ b/cron/util.js
@@ -38,9 +38,26 @@ async function vout(rpctx, blockHeight) {
   if (rpctx.vout) {
     const utxo = [];
     rpctx.vout.forEach((vout) => {
+      
+      let toAddress = 'NON_STANDARD';
+      switch (vout.scriptPubKey.type) {
+        case 'zerocoinmint':
+          toAddress = 'ZEROCOIN';
+          break;
+        case 'nulldata':
+          // store as NON_STANDARD
+          break;
+        case 'nonstandard':
+          // do not store these types of transactions
+          return;
+        default:
+          toAddress = vout.scriptPubKey.addresses[0];
+          break;
+      }
+
       const to = {
         blockHeight,
-        address: vout.scriptPubKey.type === 'zerocoinmint' ? 'ZEROCOIN' : vout.scriptPubKey.type === 'nulldata' ? 'NON_STANDARD' : vout.scriptPubKey.addresses[0] ,
+        address: toAddress,
         n: vout.n,
         value: vout.value <= 0 ? 0 : vout.value
       };


### PR DESCRIPTION
Fixes #
`'nonstandard'` case was not handled for `vout.scriptPubKey.type` resulting in syncing issues.

## Proposed Changes

  - Do not store `'nonstandard'` `scriptPubKey.type`
  - Force line endings to be LF via .gitattributes
