### PR TITLE
addPoS() will no longer store empty vout transactions

### DIFF
--- a/client/component/Card/CardStatus.jsx
+++ b/client/component/Card/CardStatus.jsx
@@ -60,11 +60,11 @@ export default class CardStatus extends Component {
         </div>
         <div className="card__row">
           <span className="card__label">Avg. Block Time:</span>
-          <span className="card__result">{ this.props.avgBlockTime.toFixed(2) } seconds</span>
+          <span className="card__result">{ (this.props.avgBlockTime || 0).toFixed(2) } seconds</span>
         </div>
         <div className="card__row">
           <span className="card__label">Avg. MN Payment:</span>
-          <span className="card__result">{ this.props.avgMNTime.toFixed(2) } hours</span>
+          <span className="card__result">{ (this.props.avgMNTime || 0).toFixed(2) } hours</span>
         </div>
       </Card>
       </div>

--- a/client/component/Footer.jsx
+++ b/client/component/Footer.jsx
@@ -69,7 +69,7 @@ class Footer extends Component {
               <a href="https://github.com/bulwark-crypto" target="_blank">
                 <Icon name="github" className="fab footer__social-media-icon" />
               </a>
-              <a href="https://twitter.com/BulwarkCoin" target="_blank">
+              <a href="https://twitter.com/BulwarkCrypto" target="_blank">
                 <Icon name="twitter" className="fab footer__social-media-icon" />
               </a>
               <a href="http://facebook.com/bulwark.coin.IO/" target="_blank">

--- a/config.template.js
+++ b/config.template.js
@@ -5,8 +5,8 @@
 const config = {
   'api': {
     'host': 'https://explorer.bulwarkcrypto.com',
-    'port': '443',
-    'portWorker': '3000',
+    'port': '3000',
+    'portWorker': '443',
     'prefix': '/api',
     'timeout': '5s'
   },

--- a/config.template.js
+++ b/config.template.js
@@ -6,6 +6,7 @@ const config = {
   'api': {
     'host': 'https://explorer.bulwarkcrypto.com',
     'port': '443',
+    'portWorker': '3000',
     'prefix': '/api',
     'timeout': '5s'
   },

--- a/cron/block.js
+++ b/cron/block.js
@@ -61,7 +61,7 @@ async function syncBlocks(start, stop, clean = false) {
 
   // Post an update to slack incoming webhook if url is
   // provided in config.js.
-  if (block && !!config.slack.url) {
+  if (block && !!config.slack && !!config.slack.url) {
     const webhook = new IncomingWebhook(config.slack.url);
     const superblock = await rpc.call('getnextsuperblock');
     const finalBlock = superblock - 1920;

--- a/cron/util.js
+++ b/cron/util.js
@@ -83,12 +83,14 @@ async function vout(rpctx, blockHeight) {
  * @param {Object} rpctx The rpc object from the node.
  */
 async function addPoS(block, rpctx) {
-  const txin = await vin(rpctx);
+  // Process & filter the outputs (this might result in an empty txout array if there are only invalid transaction types in output)
   const txout = await vout(rpctx, block.height);
 
   // We will ignore the empty PoS txs. These will not have any vouts because vout() excludes 'nulldata' and 'nonstandard' transactions
   if (rpctx.vin[0].coinbase && txout.length === 0)	
     return;
+
+  const txin = await vin(rpctx);
 
   await TX.create({
     _id: rpctx.txid,

--- a/cron/util.js
+++ b/cron/util.js
@@ -44,12 +44,11 @@ async function vout(rpctx, blockHeight) {
         case 'zerocoinmint':
           toAddress = 'ZEROCOIN';
           break;
+        // Do not store these types of transactions and continue forEach loop
         case 'nulldata':
-          // store as NON_STANDARD
-          break;
         case 'nonstandard':
-          // do not store these types of transactions
           return;
+        // By default take the first address as the "toAddress"
         default:
           toAddress = vout.scriptPubKey.addresses[0];
           break;
@@ -84,6 +83,9 @@ async function vout(rpctx, blockHeight) {
  * @param {Object} rpctx The rpc object from the node.
  */
 async function addPoS(block, rpctx) {
+  // We will ignore the empty PoS txs. These will not have any vouts because vout() excludes 'nulldata' and 'nonstandard' transactions
+  if (rpctx.vin[0].coinbase && rpctx.vout.length === 0)	
+    return;
 
   const txin = await vin(rpctx);
   const txout = await vout(rpctx, block.height);

--- a/cron/util.js
+++ b/cron/util.js
@@ -23,6 +23,11 @@ async function vin(rpctx) {
 
       txIds.add(`${ vin.txid }:${ vin.vout }`);
     });
+    
+    // Remove unspent transactions.
+    if (txIds.size) {
+      await UTXO.remove({ _id: { $in: Array.from(txIds) } });
+    }
   }
   return txin;
 }
@@ -38,18 +43,21 @@ async function vout(rpctx, blockHeight) {
   if (rpctx.vout) {
     const utxo = [];
     rpctx.vout.forEach((vout) => {
+      if (vout.value <= 0 || vout.scriptPubKey.type === 'nulldata') {
+        return;
+      }
       
       let toAddress = 'NON_STANDARD';
       switch (vout.scriptPubKey.type) {
+        case 'nulldata':
+        case 'nonstandard':
+          // These are known non-standard txouts that we won't store in txout
+          break;
         case 'zerocoinmint':
           toAddress = 'ZEROCOIN';
           break;
-        // Do not store these types of transactions and continue forEach loop
-        case 'nulldata':
-        case 'nonstandard':
-          return;
-        // By default take the first address as the "toAddress"
         default:
+          // By default take the first address as the "toAddress"
           toAddress = vout.scriptPubKey.addresses[0];
           break;
       }
@@ -58,15 +66,19 @@ async function vout(rpctx, blockHeight) {
         blockHeight,
         address: toAddress,
         n: vout.n,
-        value: vout.value <= 0 ? 0 : vout.value
+        value: vout.value
       };
 
-      txout.push(to);
+      // Always add UTXO since we'll be aggregating it in richlist
       utxo.push({
         ...to,
         _id: `${ rpctx.txid }:${ vout.n }`,
         txId: rpctx.txid
       });
+
+      if (toAddress != 'NON_STANDARD') {
+        txout.push(to);
+      }
     });
 
     // Insert unspent transactions.
@@ -83,14 +95,12 @@ async function vout(rpctx, blockHeight) {
  * @param {Object} rpctx The rpc object from the node.
  */
 async function addPoS(block, rpctx) {
-  // Process & filter the outputs (this might result in an empty txout array if there are only invalid transaction types in output)
-  const txout = await vout(rpctx, block.height);
-
-  // We will ignore the empty PoS txs. These will not have any vouts because vout() excludes 'nulldata' and 'nonstandard' transactions
-  if (rpctx.vin[0].coinbase && txout.length === 0)	
+  // We will ignore the empty PoS txs.
+  if (rpctx.vin[0].coinbase && rpctx.vout[0].value === 0)
     return;
 
   const txin = await vin(rpctx);
+  const txout = await vout(rpctx, block.height);
 
   await TX.create({
     _id: rpctx.txid,

--- a/cron/util.js
+++ b/cron/util.js
@@ -83,12 +83,12 @@ async function vout(rpctx, blockHeight) {
  * @param {Object} rpctx The rpc object from the node.
  */
 async function addPoS(block, rpctx) {
-  // We will ignore the empty PoS txs. These will not have any vouts because vout() excludes 'nulldata' and 'nonstandard' transactions
-  if (rpctx.vin[0].coinbase && rpctx.vout.length === 0)	
-    return;
-
   const txin = await vin(rpctx);
   const txout = await vout(rpctx, block.height);
+
+  // We will ignore the empty PoS txs. These will not have any vouts because vout() excludes 'nulldata' and 'nonstandard' transactions
+  if (rpctx.vin[0].coinbase && txout.length === 0)	
+    return;
 
   await TX.create({
     _id: rpctx.txid,

--- a/lib/fetch.worker.js
+++ b/lib/fetch.worker.js
@@ -12,7 +12,7 @@ require('babel-polyfill');
 const Promise = require('bluebird');
 const fetch = require('./fetch');
 
-const api = `${ process.env.config.api.host }:${ process.env.config.api.port }${ process.env.config.api.prefix }`;
+const api = `${ process.env.config.api.host }:${ process.env.config.api.portWorker }${ process.env.config.api.prefix }`;
 
 // Get the address and all transactions related.
 const getAddress = ({ address, ...query}) => fetch(`${ api }/address/${ address }`, query);

--- a/model/block.js
+++ b/model/block.js
@@ -11,7 +11,7 @@ const Block = mongoose.model('Block', new mongoose.Schema({
   __v: { select: false, type: Number },
   bits: { required: true, type: String },
   confirmations: { required: true, type: Number },
-  createdAt: { required: true, type: Date },
+  createdAt: { index: true, required: true, type: Date },
   diff: { required: true, type: String },
   hash: { index: true, required: true, type: String, unique: true },
   height: { index: true, required: true, type: Number },

--- a/model/tx.js
+++ b/model/tx.js
@@ -21,7 +21,7 @@ const TXIn = new mongoose.Schema({
  */
 const TXOut = new mongoose.Schema({
   __v: { select: false, type: Number },
-  address: { required: true, type: String },
+  address: { index: true, required: true, type: String },
   n: { required: true, type: Number },
   value: { required: true, type: Number }
 });

--- a/model/utxo.js
+++ b/model/utxo.js
@@ -6,14 +6,19 @@ const mongoose = require('mongoose');
  *
  * Unspent transactions in the blockchain.
  */
-const UTXO = mongoose.model('UTXO', new mongoose.Schema({
+const utxoSchema = new mongoose.Schema({
   __v: { select: false, type: Number },
   _id: { required: true, select: false, type: String },
-  address: { required: true, type: String },
+  address: { index: true, required: true, type: String },
   blockHeight: { index: true, required: true, type: Number },
   n: { required: true, type: Number },
   txId: { required: true, type: String },
   value: { required: true, type: Number }
-}, { versionKey: false }), 'utxo');
+}, { versionKey: false });
+
+// Add coumpound index: address_blockHeight
+utxoSchema.index({ address: 1, blockHeight: 1  });
+
+const UTXO = mongoose.model('UTXO', utxoSchema, 'utxo');
 
 module.exports =  UTXO;

--- a/server/handler/blockex.js
+++ b/server/handler/blockex.js
@@ -381,12 +381,15 @@ const getSupply = async (req, res) => {
     let c = 0; // Circulating supply.
     let t = 0; // Total supply.
 
+    //@test Temporarily disable getSupply() as it's performing a "planSummary" : "COLLSCAN" in mongodb. Need a better implementation.
+    /*
     const utxo = await UTXO.aggregate([
       { $group: { _id: 'supply', total: { $sum: '$value' } } }
     ]);
 
     t = utxo[0].total;
     c = t;
+    */
 
     res.json({ c, t });
   } catch(err) {


### PR DESCRIPTION
Fixes #
`AddPos()` will no longer store empty transactions with no vouts

## Proposed Changes

  - Both 'nulldata' and 'nonstandard' vouts will not be stored
