### PR TITLE
Move the locker.lock on cron/block.js to prevent file not found during unlock

### DIFF
--- a/cron/block.js
+++ b/cron/block.js
@@ -138,6 +138,10 @@ async function update() {
       rpcHeight = parseInt(process.argv[3], 10);
     }
     console.log(dbHeight, rpcHeight, clean);
+
+    // Create the cron lock, if return is called below the finally will still be triggered releasing the lock without errors
+    locker.lock(type);
+    
     // If nothing to do then exit.
     if (dbHeight >= rpcHeight) {
       return;
@@ -147,7 +151,6 @@ async function update() {
       dbHeight = 1;
     }
 
-    locker.lock(type);
     await syncBlocks(dbHeight, rpcHeight, clean);
   } catch(err) {
     console.log(err);


### PR DESCRIPTION
Fixes #
cron/util.js will no longer throw the following error

Error: ENOENT: no such file or directory, unlink '.../tmp/block.cron_lock'

## Proposed Changes

  - Move the `locker.lock()` above the return condition