### PR TITLE
Fb community fund address

### DIFF
--- a/client/component/Card/CardHighlightedAddresses.jsx
+++ b/client/component/Card/CardHighlightedAddresses.jsx
@@ -34,11 +34,14 @@ export default class CardHighlightedAddresses extends Component {
   };
 
   render() {
-    const { props } = this;
+    // Do not render anything if there are no addresses to highlight
+    if (this.props.addresses.length == 0) {
+      return null;
+    }
 
     return (
       <div className="watch-list">
-        <p className="watch-list__title">{ props.title }</p>
+        <p className="watch-list__title">{ this.props.title }</p>
         { this.getHighlightedAddresses() }
       </div>
     )

--- a/client/component/Card/CardHighlightedAddresses.jsx
+++ b/client/component/Card/CardHighlightedAddresses.jsx
@@ -1,52 +1,32 @@
-
-import Component from '../core/Component';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import Component from '../../core/Component';
 import Card from './Card';
-import Icon from './Icon';
+import Icon from '../Icon';
 
 export default class CardHighlightedAddresses extends Component {
-  static defaultProps = {
-    title: 'Highlighted Addresses',
-  };
-
-  static propTypes = {
-    items: PropTypes.array.isRequired,
-    loading: PropTypes.bool,
-    onSearch: PropTypes.func.isRequired,
-    title: PropTypes.string
-  };
-
+  
   handleClick = (ev, term) => {
+    /*
     try {
       this.props.onSearch(term);
     } catch(err) {
       // Do nothing.
-    }
+    }*/
   };
 
   getWatchItems() {
-    const { items } = this.props;
+    const { addresses } = this.props;
 
-    const watchItems = items.map((item, idx) => {
+    const watchItems = addresses.map((item, idx) => {
       return (
-        <div className="animated fadeIn" key={ idx }>
-          <div className="watch-list__item back-green">
+        <div className="animated fadeIn" key={ idx } onClick={ ev => this.handleClick(ev, item) } >
+          <div className="watch-list__item">
+           
             <div>
-              <Icon name="check-circle" className="far watch-list__item-close"  />
-            </div>
-            <div onClick={ ev => this.handleClick(ev, item) } >
               <div className="watch-list__item-text">
-                <h4
-                className="text-center text-white"
-                style={{
-                  fontSize: '22px',
-                  height: '22px',
-                  lineHeight: '20px'
-                }}>
-                  { item }
-                </h4>
+                { item.label }
               </div>
             </div>
           </div>
@@ -62,9 +42,9 @@ export default class CardHighlightedAddresses extends Component {
 
     return (
       <div className="watch-list">
-        <p className="watch-list__title">{ `Search History (${ props.items.length }) `}</p>
+        <p className="watch-list__title">{ props.title }</p>
         { this.getWatchItems() }
       </div>
-    );
-  };
+    )
+  }
 }

--- a/client/component/Card/CardHighlightedAddresses.jsx
+++ b/client/component/Card/CardHighlightedAddresses.jsx
@@ -1,0 +1,70 @@
+
+import Component from '../core/Component';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Card from './Card';
+import Icon from './Icon';
+
+export default class CardHighlightedAddresses extends Component {
+  static defaultProps = {
+    title: 'Highlighted Addresses',
+  };
+
+  static propTypes = {
+    items: PropTypes.array.isRequired,
+    loading: PropTypes.bool,
+    onSearch: PropTypes.func.isRequired,
+    title: PropTypes.string
+  };
+
+  handleClick = (ev, term) => {
+    try {
+      this.props.onSearch(term);
+    } catch(err) {
+      // Do nothing.
+    }
+  };
+
+  getWatchItems() {
+    const { items } = this.props;
+
+    const watchItems = items.map((item, idx) => {
+      return (
+        <div className="animated fadeIn" key={ idx }>
+          <div className="watch-list__item back-green">
+            <div>
+              <Icon name="check-circle" className="far watch-list__item-close"  />
+            </div>
+            <div onClick={ ev => this.handleClick(ev, item) } >
+              <div className="watch-list__item-text">
+                <h4
+                className="text-center text-white"
+                style={{
+                  fontSize: '22px',
+                  height: '22px',
+                  lineHeight: '20px'
+                }}>
+                  { item }
+                </h4>
+              </div>
+            </div>
+          </div>
+        </div>
+      )
+    });
+
+    return watchItems
+  };
+
+  render() {
+    const { props } = this;
+
+    return (
+      <div className="watch-list">
+        <p className="watch-list__title">{ `Search History (${ props.items.length }) `}</p>
+        { this.getWatchItems() }
+      </div>
+    );
+  };
+}

--- a/client/component/Card/CardHighlightedAddresses.jsx
+++ b/client/component/Card/CardHighlightedAddresses.jsx
@@ -8,22 +8,18 @@ import Icon from '../Icon';
 export default class CardHighlightedAddresses extends Component {
   
   handleClick = (ev, term) => {
-    /*
     try {
-      this.props.onSearch(term);
+      this.props.onSearch(term.address);
     } catch(err) {
       // Do nothing.
-    }*/
+    }
   };
 
-  getWatchItems() {
-    const { addresses } = this.props;
-
-    const watchItems = addresses.map((item, idx) => {
+  getHighlightedAddresses() {
+    const highlightedAddresses = this.props.addresses.map((item, idx) => {
       return (
         <div className="animated fadeIn" key={ idx } onClick={ ev => this.handleClick(ev, item) } >
-          <div className="watch-list__item">
-           
+          <div className="watch-list__item">           
             <div>
               <div className="watch-list__item-text">
                 { item.label }
@@ -34,7 +30,7 @@ export default class CardHighlightedAddresses extends Component {
       )
     });
 
-    return watchItems
+    return highlightedAddresses
   };
 
   render() {
@@ -43,7 +39,7 @@ export default class CardHighlightedAddresses extends Component {
     return (
       <div className="watch-list">
         <p className="watch-list__title">{ props.title }</p>
-        { this.getWatchItems() }
+        { this.getHighlightedAddresses() }
       </div>
     )
   }

--- a/client/container/Address.jsx
+++ b/client/container/Address.jsx
@@ -41,8 +41,7 @@ class Address extends Component {
 
   componentDidUpdate() {
     if (!!this.state.address
-      && this.state.address !== this.props.match.params.hash) {
-      this.setState({ address: this.props.match.params.hash }); // Set state to new adress to prevent calling getAddress() multiple times
+      && this.state.address !== this.props.match.params.hash && !this.state.loading) {
       this.getAddress();
     }
   };

--- a/client/container/Address.jsx
+++ b/client/container/Address.jsx
@@ -42,6 +42,7 @@ class Address extends Component {
   componentDidUpdate() {
     if (!!this.state.address
       && this.state.address !== this.props.match.params.hash) {
+      this.setState({ address: this.props.match.params.hash }); // Set state to new adress to prevent calling getAddress() multiple times
       this.getAddress();
     }
   };

--- a/client/container/CoinSummary.jsx
+++ b/client/container/CoinSummary.jsx
@@ -87,6 +87,7 @@ class CoinSummary extends Component {
             <CardHighlightedAddresses
               title="Community Addresses"
               addresses={ config.community.highlightedAddresses }
+              onSearch={ this.props.onSearch }
              />
             <WatchList
               items={ watchlist }

--- a/client/container/CoinSummary.jsx
+++ b/client/container/CoinSummary.jsx
@@ -1,4 +1,5 @@
 
+import config from '../../config'
 import Actions from '../core/Actions';
 import blockchain from '../../lib/blockchain';
 import Component from '../core/Component';
@@ -85,9 +86,7 @@ class CoinSummary extends Component {
               ssHeight={ blockchain.params.LAST_SEESAW_BLOCK } />
             <CardHighlightedAddresses
               title="Community Addresses"
-              addresses={
-                { label: "Perpetual Funding", address: "bWKFundnxm6xtER3hX8gtYtZbVNTFEZ79u" }
-              }
+              addresses={ config.community.highlightedAddresses }
              />
             <WatchList
               items={ watchlist }

--- a/client/container/CoinSummary.jsx
+++ b/client/container/CoinSummary.jsx
@@ -10,6 +10,7 @@ import Icon from '../component/Icon';
 
 import CardMarket from '../component/Card/CardMarket';
 import CardMasternodeSummary from '../component/Card/CardMasternodeSummary';
+import CardHighlightedAddresses from '../component/Card/CardHighlightedAddresses';
 import CardPoS from '../component/Card/CardPoS';
 import CardPoSCalc from '../component/Card/CardPoSCalc';
 import CardStatus from '../component/Card/CardStatus';
@@ -82,6 +83,12 @@ class CoinSummary extends Component {
               average={ coin.avgBlockTime }
               height={ height }
               ssHeight={ blockchain.params.LAST_SEESAW_BLOCK } />
+            <CardHighlightedAddresses
+              title="Community Addresses"
+              addresses={
+                { label: "Perpetual Funding", address: "bWKFundnxm6xtER3hX8gtYtZbVNTFEZ79u" }
+              }
+             />
             <WatchList
               items={ watchlist }
               onSearch={ this.props.onSearch }

--- a/config.template.js
+++ b/config.template.js
@@ -39,7 +39,8 @@ const config = {
   },
   'community': {
     'highlightedAddresses': [
-      { label: "Perpetual Community Funding", address: "bWKFundnxm6xtER3hX8gtYtZbVNTFEZ79u" }
+      //{ label: "Community Donations", address: "XXXXXXXXXXXXXXXXXXXXXXXXXXX" }, // Uncomment and replace with your coin address to highlight an address
+      //{ label: "Community Funding", address: "XXXXXXXXXXXXXXXXXXXXXXXXXXX" }, // Uncomment and replace with your coin address to highlight any other address
     ]
   }
 };

--- a/config.template.js
+++ b/config.template.js
@@ -36,6 +36,11 @@ const config = {
     //'channel': '#general',
     //'username': 'Block Report',
     //'icon_emoji': ':bwk:'
+  },
+  'community': {
+    'highlightedAddresses': [
+      { label: "Perpetual Community Funding", address: "bWKFundnxm6xtER3hX8gtYtZbVNTFEZ79u" }
+    ]
   }
 };
 

--- a/config.template.js
+++ b/config.template.js
@@ -39,6 +39,7 @@ const config = {
   },
   'community': {
     'highlightedAddresses': [
+      // If you comment out all of these addresses the "Community Addresses" section will not show up on the homepage. You can add as many addresses to highlight as you wish.
       //{ label: "Community Donations", address: "XXXXXXXXXXXXXXXXXXXXXXXXXXX" }, // Uncomment and replace with your coin address to highlight an address
       //{ label: "Community Funding", address: "XXXXXXXXXXXXXXXXXXXXXXXXXXX" }, // Uncomment and replace with your coin address to highlight any other address
     ]


### PR DESCRIPTION
Fixes #
 - `getAddress()` was being called multiple times because the state kept changing and re-triggering `componentDidUpdate()` which in turn calls `getAddress()`

## Proposed Changes
  - Added new widget to highlight different addresses. Coins that fork our explorer can choose to select their own title and set of addresses to highlight on the homepage.
