### PR TITLE
Another caching fix for key name

### DIFF
--- a/server/lib/cache.js
+++ b/server/lib/cache.js
@@ -11,9 +11,9 @@ let cacheData = {};
 let cacheUnixTimestamps = {};
 const getFromCache = async (cacheName, expiryUnixTimestamp, callback) => {
   const currentUnixTimestamp = moment().utc().unix();
-  if (!cacheData[cacheName] || cacheUnixTimestamps[expiryUnixTimestamp] < currentUnixTimestamp) {
+  if (!cacheData[cacheName] || cacheUnixTimestamps[cacheName] < currentUnixTimestamp) {
     cacheData[cacheName] = await callback();
-    cacheUnixTimestamps[expiryUnixTimestamp] = expiryUnixTimestamp;
+    cacheUnixTimestamps[cacheName] = expiryUnixTimestamp;
   }
   return cacheData[cacheName];
 };


### PR DESCRIPTION
Fixes #
Cache unix timestamps were not accessed by a proper key name