### PR TITLE
Split Masternodes table into component

### DIFF
--- a/client/component/MasternodesList.jsx
+++ b/client/component/MasternodesList.jsx
@@ -1,0 +1,159 @@
+import Component from '../core/Component';
+import { dateFormat } from '../../lib/date';
+import { Link } from 'react-router-dom';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import React from 'react';
+import sortBy from 'lodash/sortBy';
+
+import HorizontalRule from '../component/HorizontalRule';
+import Pagination from '../component/Pagination';
+import Table from '../component/Table';
+import Select from '../component/Select';
+import Icon from '../component/Icon';
+
+import { PAGINATION_PAGE_SIZE } from '../constants';
+
+class MasternodesList extends Component {
+  static propTypes = {
+    getMNs: PropTypes.func.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    this.debounce = null;
+    this.state = {
+      cols: [
+        { key: 'lastPaidAt', title: 'Last Paid' },
+        { key: 'active', title: 'Active' },
+        { key: 'addr', title: 'Address' },
+        { key: 'txHash', title: 'Collateral TX' },
+        { key: 'txOutIdx', title: 'Index' },
+        { key: 'ver', title: 'Version' },
+        { key: 'status', title: 'Status' },
+      ],
+      error: null,
+      loading: true,
+      mns: [] ,
+      pages: 0,
+      page: 1,
+      size: 10
+    };
+  };
+
+  componentDidMount() {
+    this.getMNs();
+  };
+
+  componentWillUnmount() {
+    if (this.debounce) {
+      clearTimeout(this.debounce);
+      this.debounce = null;
+    }
+  };
+
+  getMNs = () => {
+    this.setState({ loading: true }, () => {
+      if (this.debounce) {
+        clearTimeout(this.debounce);
+      }
+
+      this.debounce = setTimeout(() => {
+        this.props
+          .getMNs({
+            limit: this.state.size,
+            skip: (this.state.page - 1) * this.state.size
+          })
+          .then(({ mns, pages }) => {
+            if (this.debounce) {
+              this.setState({ mns, pages, loading: false });
+            }
+          })
+          .catch(error => this.setState({ error, loading: false }));
+      }, 800);
+    });
+  };
+
+  handlePage = page => this.setState({ page }, this.getMNs);
+
+  handleSize = size => this.setState({ size, page: 1 }, this.getMNs);
+
+  render() {
+    if (!!this.state.error) {
+      return this.renderError(this.state.error);
+    } else if (this.state.loading) {
+      return this.renderLoading();
+    }
+    const selectOptions = PAGINATION_PAGE_SIZE;
+
+    const select = (
+      <Select
+        onChange={ value => this.handleSize(value) }
+        selectedValue={ this.state.size }
+        options={ selectOptions } />
+    );
+
+    const getIcon = (mn) =>{
+      switch (mn.network) {
+        case "onion":
+          return (
+            <span title="Onion Network"><Icon name="user-secret" className="pr-1 text-primary fa-lg" /></span>
+          )
+        case "ipv6":
+          return (
+            <span title="IPv6"><Icon name="desktop" className="pr-1 text-primary fa-lg" /></span>
+          )
+        default:
+          return null;
+      }
+    }
+
+    // Calculate the future so we can use it to
+    // sort by lastPaid in descending order.
+    const future = moment().add(2, 'years').utc().unix();
+
+    return (
+      <div>
+        <HorizontalRule
+          select={ select }
+          title="Masternodes" />
+        <Table
+          cols={ this.state.cols }
+          data={ sortBy(this.state.mns.map((mn) => {
+            const lastPaidAt = moment(mn.lastPaidAt).utc();
+            const isEpoch = lastPaidAt.unix() === 0;
+
+            return {
+              ...mn,
+              active: moment().subtract(mn.active, 'seconds').utc().fromNow(),
+              addr: (
+                <Link to={ `/address/${ mn.addr }` }>
+                  { `${ mn.addr.substr(0, 20) }...` }
+                </Link>
+              ),
+              lastPaidAt: isEpoch ? 'N/A' : dateFormat(mn.lastPaidAt),
+              txHash: (
+                <Link to={ `/tx/${ mn.txHash }` }>
+                  { `${ mn.txHash.substr(0, 20) }...` }
+                </Link>
+              ),
+              status: (
+                <span>
+                  { getIcon(mn) }
+                  { mn.status }
+                </span>
+              )
+            };
+          }), ['status']) } />
+        <Pagination
+          current={ this.state.page }
+          className="float-right"
+          onPage={ this.handlePage }
+          total={ this.state.pages } />
+        <div className="clearfix" />
+      </div>
+    );
+  };
+}
+
+export default MasternodesList;

--- a/client/component/MasternodesList.jsx
+++ b/client/component/MasternodesList.jsx
@@ -138,7 +138,7 @@ class MasternodesList extends Component {
                 </Link>
               ),
               status: (
-                <span>
+                <span class="text-nowrap">
                   { getIcon(mn) }
                   { mn.status }
                 </span>

--- a/client/component/MasternodesList.jsx
+++ b/client/component/MasternodesList.jsx
@@ -16,7 +16,9 @@ import { PAGINATION_PAGE_SIZE } from '../constants';
 
 class MasternodesList extends Component {
   static propTypes = {
-    getMNs: PropTypes.func.isRequired
+    title: PropTypes.string.isRequired,
+    getMNs: PropTypes.func.isRequired,
+    isPaginationEnabled: PropTypes.bool.isRequired
   };
 
   constructor(props) {
@@ -34,7 +36,7 @@ class MasternodesList extends Component {
       ],
       error: null,
       loading: true,
-      mns: [] ,
+      mns: [],
       pages: 0,
       page: 1,
       size: 10
@@ -86,14 +88,30 @@ class MasternodesList extends Component {
     }
     const selectOptions = PAGINATION_PAGE_SIZE;
 
-    const select = (
-      <Select
-        onChange={ value => this.handleSize(value) }
-        selectedValue={ this.state.size }
-        options={ selectOptions } />
-    );
+    const getPaginationDropdown = () => {
+      if (!this.props.isPaginationEnabled) {
+        return null;
+      }
+      return (
+        <Select
+          onChange={value => this.handleSize(value)}
+          selectedValue={this.state.size}
+          options={selectOptions} />
+      );
+    };
 
-    const getIcon = (mn) =>{
+    const getPaginationControls = () => {
+      if (!this.props.isPaginationEnabled) {
+        return null;
+      }
+      return (<Pagination
+        current={this.state.page}
+        className="float-right"
+        onPage={this.handlePage}
+        total={this.state.pages} />);
+    }
+
+    const getIcon = (mn) => {
       switch (mn.network) {
         case "onion":
           return (
@@ -115,11 +133,11 @@ class MasternodesList extends Component {
     return (
       <div>
         <HorizontalRule
-          select={ select }
-          title="Masternodes" />
+          select={getPaginationDropdown()}
+          title={this.props.title} />
         <Table
-          cols={ this.state.cols }
-          data={ sortBy(this.state.mns.map((mn) => {
+          cols={this.state.cols}
+          data={sortBy(this.state.mns.map((mn) => {
             const lastPaidAt = moment(mn.lastPaidAt).utc();
             const isEpoch = lastPaidAt.unix() === 0;
 
@@ -127,29 +145,25 @@ class MasternodesList extends Component {
               ...mn,
               active: moment().subtract(mn.active, 'seconds').utc().fromNow(),
               addr: (
-                <Link to={ `/address/${ mn.addr }` }>
-                  { `${ mn.addr.substr(0, 20) }...` }
+                <Link to={`/address/${mn.addr}`}>
+                  {`${mn.addr.substr(0, 20)}...`}
                 </Link>
               ),
               lastPaidAt: isEpoch ? 'N/A' : dateFormat(mn.lastPaidAt),
               txHash: (
-                <Link to={ `/tx/${ mn.txHash }` }>
-                  { `${ mn.txHash.substr(0, 20) }...` }
+                <Link to={`/tx/${mn.txHash}`}>
+                  {`${mn.txHash.substr(0, 20)}...`}
                 </Link>
               ),
               status: (
-                <span class="text-nowrap">
-                  { getIcon(mn) }
-                  { mn.status }
+                <span className="text-nowrap">
+                  {getIcon(mn)}
+                  {mn.status}
                 </span>
               )
             };
-          }), ['status']) } />
-        <Pagination
-          current={ this.state.page }
-          className="float-right"
-          onPage={ this.handlePage }
-          total={ this.state.pages } />
+          }), ['status'])} />
+        {getPaginationControls()}
         <div className="clearfix" />
       </div>
     );

--- a/client/component/MasternodesList.jsx
+++ b/client/component/MasternodesList.jsx
@@ -157,7 +157,7 @@ class MasternodesList extends Component {
                   {`${mn.addr.substr(0, 20)}...`}
                 </Link>
               ),
-              lastPaidAt: isEpoch ? 'N/A' : dateFormat(mn.lastPaidAt),
+              lastPaidAt: isEpoch ? 'N/A' : lastPaidAt.fromNow(),
               txHash: (
                 <Link to={`/tx/${mn.txHash}`}>
                   {`${mn.txHash.substr(0, 20)}...`}

--- a/client/component/MasternodesList.jsx
+++ b/client/component/MasternodesList.jsx
@@ -18,7 +18,8 @@ class MasternodesList extends Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
     getMNs: PropTypes.func.isRequired,
-    isPaginationEnabled: PropTypes.bool.isRequired
+    isPaginationEnabled: PropTypes.bool.isRequired,
+    hideCols: PropTypes.array
   };
 
   constructor(props) {
@@ -41,6 +42,13 @@ class MasternodesList extends Component {
       page: 1,
       size: 10
     };
+
+    // You can optionally pass in array of columns to hide in masternodes table
+    if (!!this.props.hideCols) {
+      this.state.cols = this.state.cols.filter((value) => {
+        return !this.props.hideCols.includes(value.key);
+      });
+    }
   };
 
   componentDidMount() {

--- a/client/container/Address.jsx
+++ b/client/container/Address.jsx
@@ -80,7 +80,7 @@ class Address extends Component {
       return null;
     }
     return (
-      <MasternodesList title="Masternode For Address" isPaginationEnabled={false} getMNs={this.props.getMNs.bind(this)} />
+      <MasternodesList title="Masternode For Address" isPaginationEnabled={false} getMNs={this.props.getMNs} hideCols={["addr"]} />
     );
   }
 
@@ -132,7 +132,7 @@ class Address extends Component {
 const mapDispatch = (dispatch, ownProps) => ({
   getAddress: query => Actions.getAddress(query),
   getMNs: query => {
-    query.hash = ownProps.match.params.hash; // Add current wallet address to the filtering of getMNs()
+    query.hash = ownProps.match.params.hash; // Add current wallet address to the filtering of getMNs(). Look at server/handler/blockex.js getMasternodes()
     return Actions.getMNs(query);
   }
 });

--- a/client/container/Masternode.jsx
+++ b/client/container/Masternode.jsx
@@ -11,13 +11,15 @@ class Masternode extends Component {
   };
   render() {
     return (
-      <MasternodesList getMNs= { this.props.getMNs } />
+      <MasternodesList title="Masternodes" isPaginationEnabled={true} getMNs={this.props.getMNs} />
     );
   };
 }
 
 const mapDispatch = dispatch => ({
-  getMNs: query => Actions.getMNs(query)
+  getMNs: query => {
+    return Actions.getMNs(query);
+  }
 });
 
 export default connect(null, mapDispatch)(Masternode);

--- a/client/container/Masternode.jsx
+++ b/client/container/Masternode.jsx
@@ -1,160 +1,17 @@
-
 import Actions from '../core/Actions';
 import Component from '../core/Component';
-import { connect } from 'react-redux';
-import { dateFormat } from '../../lib/date';
-import { Link } from 'react-router-dom';
-import moment from 'moment';
-import PropTypes from 'prop-types';
+import MasternodesList from '../component/MasternodesList';
 import React from 'react';
-import sortBy from 'lodash/sortBy';
-
-import HorizontalRule from '../component/HorizontalRule';
-import Pagination from '../component/Pagination';
-import Table from '../component/Table';
-import Select from '../component/Select';
-import Icon from '../component/Icon';
-
-import { PAGINATION_PAGE_SIZE } from '../constants';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 class Masternode extends Component {
   static propTypes = {
     getMNs: PropTypes.func.isRequired
   };
-
-  constructor(props) {
-    super(props);
-    this.debounce = null;
-    this.state = {
-      cols: [
-        { key: 'lastPaidAt', title: 'Last Paid' },
-        { key: 'active', title: 'Active' },
-        { key: 'addr', title: 'Address' },
-        { key: 'txHash', title: 'Collateral TX' },
-        { key: 'txOutIdx', title: 'Index' },
-        { key: 'ver', title: 'Version' },
-        { key: 'status', title: 'Status' },
-      ],
-      error: null,
-      loading: true,
-      mns: [] ,
-      pages: 0,
-      page: 1,
-      size: 10
-    };
-  };
-
-  componentDidMount() {
-    this.getMNs();
-  };
-
-  componentWillUnmount() {
-    if (this.debounce) {
-      clearTimeout(this.debounce);
-      this.debounce = null;
-    }
-  };
-
-  getMNs = () => {
-    this.setState({ loading: true }, () => {
-      if (this.debounce) {
-        clearTimeout(this.debounce);
-      }
-
-      this.debounce = setTimeout(() => {
-        this.props
-          .getMNs({
-            limit: this.state.size,
-            skip: (this.state.page - 1) * this.state.size
-          })
-          .then(({ mns, pages }) => {
-            if (this.debounce) {
-              this.setState({ mns, pages, loading: false });
-            }
-          })
-          .catch(error => this.setState({ error, loading: false }));
-      }, 800);
-    });
-  };
-
-  handlePage = page => this.setState({ page }, this.getMNs);
-
-  handleSize = size => this.setState({ size, page: 1 }, this.getMNs);
-
   render() {
-    if (!!this.state.error) {
-      return this.renderError(this.state.error);
-    } else if (this.state.loading) {
-      return this.renderLoading();
-    }
-    const selectOptions = PAGINATION_PAGE_SIZE;
-
-    const select = (
-      <Select
-        onChange={ value => this.handleSize(value) }
-        selectedValue={ this.state.size }
-        options={ selectOptions } />
-    );
-
-    const getIcon = (mn) =>{
-      switch (mn.network) {
-        case "onion":
-          return (
-            <span title="Onion Network"><Icon name="user-secret" className="pr-1 text-primary fa-lg" /></span>
-          )
-        case "ipv6":
-          return (
-            <span title="IPv6"><Icon name="desktop" className="pr-1 text-primary fa-lg" /></span>
-          )
-        default:
-          return null;
-      }
-    }
-
-    // Calculate the future so we can use it to
-    // sort by lastPaid in descending order.
-    const future = moment().add(2, 'years').utc().unix();
-
     return (
-      <div>
-        <HorizontalRule
-          select={ select }
-          title="Masternodes" />
-        <Table
-          cols={ this.state.cols }
-          data={ sortBy(this.state.mns.map((mn) => {
-            const lastPaidAt = moment(mn.lastPaidAt).utc();
-            const isEpoch = lastPaidAt.unix() === 0;
-
-            return {
-              ...mn,
-              active: moment().subtract(mn.active, 'seconds').utc().fromNow(),
-              addr: (
-                <Link to={ `/address/${ mn.addr }` }>
-                  { `${ mn.addr.substr(0, 20) }...` }
-                </Link>
-              ),
-              lastPaidAt: isEpoch ? 'N/A' : dateFormat(mn.lastPaidAt),
-              txHash: (
-                <Link to={ `/tx/${ mn.txHash }` }>
-                  { `${ mn.txHash.substr(0, 20) }...` }
-                </Link>
-              ),
-              status: (
-                <span>
-                  { getIcon(mn) }
-                  { mn.status }
-                </span>
-              )
-            };
-          }), ['status']) } />
-        <Pagination
-          current={ this.state.page }
-          className="float-right"
-          onPage={ this.handlePage }
-          total={ this.state.pages } />
-        <div className="clearfix" />
-      </div>
+      <MasternodesList getMNs= { this.props.getMNs } />
     );
   };
 }

--- a/client/core/Actions.jsx
+++ b/client/core/Actions.jsx
@@ -86,7 +86,7 @@ export const getIsBlock = (query) => {
 
 export const getMNs = (query) => {
   return new promise((resolve, reject) => {
-    return getFromWorker('mns', resolve, reject, query);
+    return getFromWorker('mns', resolve, reject, query); // Resolves to getMNs in fetch.worker.js
   });
 };
 

--- a/server/handler/blockex.js
+++ b/server/handler/blockex.js
@@ -315,6 +315,7 @@ const getMasternodes = async (req, res) => {
     const skip = req.query.skip ? parseInt(req.query.skip, 10) : 0;
 
     var query = {};
+    // Optionally it's possible to filter masternodes running on a specific address
     if (req.query.hash) {
       query.addr = req.query.hash;
     }


### PR DESCRIPTION
## Proposed Changes

  - Split out masternodes list into it's own component
  - Masternodes type icon will no longer wrap on mobile
  - MasternodesList now has togglable pagination and customizable title
  - Added masternode filtering by address & /address/:hash now returns  `isMasternode` bool
  - Added masternode for address. This will be visible if the address is running a masternode
  - Added hideCols to masternodes for address (We hide the address column when on the address page)
  - Added readable format for masternode payments (New date format)
