### PR TITLE
Address Widgets & Community Masternodes List

### DIFF
--- a/client/container/Address.jsx
+++ b/client/container/Address.jsx
@@ -1,9 +1,12 @@
 
+import configUtils from '../../lib/configUtils';
+
 import Actions from '../core/Actions';
 import Component from '../core/Component';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 
 import CardAddress from '../component/Card/CardAddress';
 import CardAddressTXs from '../component/Card/CardAddressTXs';
@@ -83,6 +86,18 @@ class Address extends Component {
       <MasternodesList title="Masternode For Address" isPaginationEnabled={false} getMNs={this.props.getMNs} hideCols={["addr"]} />
     );
   }
+  getMasternodesAddressWidget = () => {
+    const address = this.props.match.params.hash;
+    const masternodesAddressWidget = configUtils.getCommunityAddressWidgetConfig(address, "masternodesAddressWidget");
+    if (!masternodesAddressWidget) {
+      return null;
+    }
+
+    return (
+      <MasternodesList title={masternodesAddressWidget.title} isPaginationEnabled={false} getMNs={this.props.getMasternodesAddressWidget} />
+    );
+  }
+
 
   render() {
     if (!!this.state.error) {
@@ -124,15 +139,26 @@ class Address extends Component {
           total={this.state.pages} />
         <div className="clearfix" />
         {this.getMasternodeDetails()}
+        {this.getMasternodesAddressWidget()}
       </div>
     );
   };
 }
 
+
 const mapDispatch = (dispatch, ownProps) => ({
   getAddress: query => Actions.getAddress(query),
   getMNs: query => {
     query.hash = ownProps.match.params.hash; // Add current wallet address to the filtering of getMNs(). Look at server/handler/blockex.js getMasternodes()
+    return Actions.getMNs(query);
+  },
+  getMasternodesAddressWidget: query => {
+    const address = ownProps.match.params.hash;
+    const masternodesAddressWidget = configUtils.getCommunityAddressWidgetConfig(address, "masternodesAddressWidget");
+    if (!masternodesAddressWidget) {
+      return null;
+    }
+    query.addresses = masternodesAddressWidget.addresses; // Add array of wallet addresses to the filtering of getMNs(). Look at server/handler/blockex.js getMasternodes()
     return Actions.getMNs(query);
   }
 });

--- a/client/container/CoinSummary.jsx
+++ b/client/container/CoinSummary.jsx
@@ -41,6 +41,19 @@ class CoinSummary extends Component {
       ? this.props.searches
       : this.props.searches.slice(0, 7);
 
+    const getCardHighlightedAddresses = () => {
+      if (!config.community) {
+        return null;
+      }
+      return (
+        <CardHighlightedAddresses
+          title="Community Addresses"
+          addresses={config.community.highlightedAddresses}
+          onSearch={this.props.onSearch}
+        />
+      );
+    };
+
     return (
       <div>
         <div className="row">
@@ -48,11 +61,11 @@ class CoinSummary extends Component {
             <div className="row">
               <div className="col-md-12 col-lg-6">
                 <CardStatus
-                  avgBlockTime={ coin.avgBlockTime }
-                  avgMNTime={ coin.avgMNTime }
-                  blocks={ height }
-                  peers={ coin.peers }
-                  status={ coin.status } />
+                  avgBlockTime={coin.avgBlockTime}
+                  avgMNTime={coin.avgMNTime}
+                  blocks={height}
+                  peers={coin.peers}
+                  status={coin.status} />
               </div>
               <div className="col-md-12 col-lg-6">
                 <CardPoSCalc />
@@ -61,38 +74,35 @@ class CoinSummary extends Component {
             <div className="row">
               <div className="col-md-12 col-lg-6">
                 <CardMarket
-                  btc={ coin.btc }
-                  usd={ coin.usd }
-                  xAxis={ this.props.coins.map(c => c.createdAt) }
-                  yAxis={ this.props.coins.map(c => c.usd ? c.usd : 0.0) } />
+                  btc={coin.btc}
+                  usd={coin.usd}
+                  xAxis={this.props.coins.map(c => c.createdAt)}
+                  yAxis={this.props.coins.map(c => c.usd ? c.usd : 0.0)} />
               </div>
               <div className="col-md-12 col-lg-6">
                 <CardMasternodeSummary
-                  offline={ coin.mnsOff }
-                  online={ coin.mnsOn }
-                  xAxis={ this.props.coins.map(c => c.createdAt) }
-                  yAxis={ this.props.coins.map(c => c.mnsOn ? c.mnsOn : 0.0) } />
+                  offline={coin.mnsOff}
+                  online={coin.mnsOn}
+                  xAxis={this.props.coins.map(c => c.createdAt)}
+                  yAxis={this.props.coins.map(c => c.mnsOn ? c.mnsOn : 0.0)} />
               </div>
             </div>
           </div>
           <div className="col-md-12 col-lg-3">
             <CardPoS
-              average={ coin.avgBlockTime }
-              height={ height }
-              posHeight={ blockchain.params.LAST_POW_BLOCK } />
+              average={coin.avgBlockTime}
+              height={height}
+              posHeight={blockchain.params.LAST_POW_BLOCK} />
             <CardSeeSaw
-              average={ coin.avgBlockTime }
-              height={ height }
-              ssHeight={ blockchain.params.LAST_SEESAW_BLOCK } />
-            <CardHighlightedAddresses
-              title="Community Addresses"
-              addresses={ config.community.highlightedAddresses }
-              onSearch={ this.props.onSearch }
-             />
+              average={coin.avgBlockTime}
+              height={height}
+              ssHeight={blockchain.params.LAST_SEESAW_BLOCK} />
+            {getCardHighlightedAddresses()}
+
             <WatchList
-              items={ watchlist }
-              onSearch={ this.props.onSearch }
-              onRemove={ this.props.onRemove } />
+              items={watchlist}
+              onSearch={this.props.onSearch}
+              onRemove={this.props.onRemove} />
           </div>
         </div>
       </div>

--- a/config.template.js
+++ b/config.template.js
@@ -1,48 +1,62 @@
-
 /**
  * Global configuration object.
  */
 const config = {
-  'api': {
+  api: {
     'host': 'https://explorer.bulwarkcrypto.com',
     'port': '3000',
     'portWorker': '443',
     'prefix': '/api',
     'timeout': '5s'
   },
-  'coinMarketCap': {
+  coinMarketCap: {
     'api': 'http://api.coinmarketcap.com/v1/ticker/',
     'ticker': 'bulwark'
   },
-  'db': {
+  db: {
     'host': '127.0.0.1',
     'port': '27017',
     'name': 'blockex',
     'user': 'blockexuser',
     'pass': 'Explorer!1'
   },
-  'freegeoip': {
+  freegeoip: {
     'api': 'https://extreme-ip-lookup.com/json/'
   },
-  'rpc': {
+  rpc: {
     'host': '127.0.0.1',
     'port': '52541',
     'user': 'bulwarkrpc',
     'pass': 'someverysafepassword',
     'timeout': 8000, // 8 seconds
   },
-  'slack': {
+  slack: {
     'url': 'https://hooks.slack.com/services/A00000000/B00000000/somekindofhashhere',
     //'channel': '#general',
     //'username': 'Block Report',
     //'icon_emoji': ':bwk:'
   },
-  'community': {
-    'highlightedAddresses': [
+  community: {
+    highlightedAddresses: [
       // If you comment out all of these addresses the "Community Addresses" section will not show up on the homepage. You can add as many addresses to highlight as you wish.
       //{ label: "Community Donations", address: "XXXXXXXXXXXXXXXXXXXXXXXXXXX" }, // Uncomment and replace with your coin address to highlight an address
       //{ label: "Community Funding", address: "XXXXXXXXXXXXXXXXXXXXXXXXXXX" }, // Uncomment and replace with your coin address to highlight any other address
     ]
+  },
+  // Each address can contain it's own set of widgets and configs for those widgets
+  addressWidgets: {
+    "XXXXXXXXXXXXXXXXXXXXXXXXXXX": {
+      // WIDGET: Adds a list of masternodes when viewing address. We use this to show community-ran masternodes
+      masternodesAddressWidget: {
+        title: "Community Masternodes",
+        description: "Profits from these masternodes fund & fuel community talent",
+        addresses: [
+          "XXXXXXXXXXXXXXXXXXXXXXXXXXX",
+          "XXXXXXXXXXXXXXXXXXXXXXXXXXX",
+          "XXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        ]
+      }
+    }
   }
 };
 

--- a/lib/configUtils.js
+++ b/lib/configUtils.js
@@ -1,0 +1,27 @@
+import config from '../config'
+// Allows to quickly find a matching config for this address
+const getCommunityAddressConfig = (addressToFind) => {
+    if (!config.addressWidgets || !config.addressWidgets) {
+        return null;
+    }
+
+    return config.addressWidgets[addressToFind];
+}
+// Allows to quickly find a matching config for this widget in this address
+const getCommunityAddressWidgetConfig = (addressToFind, widgetConfig) => {
+    const communityAddressConfig = getCommunityAddressConfig(addressToFind);
+    if (!communityAddressConfig) {
+        return null;
+    }
+    const addressWidget = communityAddressConfig[widgetConfig];
+    if (!addressWidget) {
+        return null;
+    }
+    return addressWidget;
+}
+
+
+module.exports = {
+    getCommunityAddressConfig,
+    getCommunityAddressWidgetConfig
+};

--- a/server/handler/blockex.js
+++ b/server/handler/blockex.js
@@ -315,9 +315,20 @@ const getMasternodes = async (req, res) => {
     const skip = req.query.skip ? parseInt(req.query.skip, 10) : 0;
 
     var query = {};
+    
     // Optionally it's possible to filter masternodes running on a specific address
     if (req.query.hash) {
-      query.addr = req.query.hash;
+      query.addr = req.query.hash;      
+    }
+
+    // Optionally it's possible to filter masternodes running on a specific range of addresses. Pass in addresses as comma-seprated list
+    // In redux we pass in an array and it automatically converts into a comma-seperated list of addresses
+    if (req.query.addresses) {
+      // At the moment the limit of addresses in a single query is 25 but this number will be increased later, perhaps with some form of caching
+      if (req.query.addresses.length < 25) {
+        const addressList = req.query.addresses.split(',');
+        query.addr = { "$in": addressList };
+      }
     }
 
     const total = await Masternode.count(query);


### PR DESCRIPTION
Fixes #

  - Improved backwards compatibility for other forks of Bulwark Explorer

## Proposed Changes

  - New "Address Widgets" which allow certain addresses to have their own sets of widgets. For now there is only one widget to list masternodes for an address. We use this for community masternodes.
