### PR TITLE
Switching between blocks & txs will no longer infinitely loop

### DIFF
--- a/client/container/Block.jsx
+++ b/client/container/Block.jsx
@@ -32,7 +32,7 @@ class Block extends Component {
 
   componentDidUpdate(prevProps) {
     const { params: { hash } } = this.props.match;
-    if (prevProps.match.params.hash !== hash) {
+    if (prevProps.match.params.hash !== hash && !this.state.loading) {
       this.getBlock();
     }
   };

--- a/client/container/TX.jsx
+++ b/client/container/TX.jsx
@@ -38,7 +38,7 @@ class TX extends Component {
 
   componentDidUpdate() {
     const { params: { hash } } = this.props.match;
-    if (!!this.state.tx.txId && hash !== this.state.tx.txId) {
+    if (!!this.state.tx.txId && hash !== this.state.tx.txId && !this.state.loading) {
       this.getTX();
     }
   };


### PR DESCRIPTION
## Proposed Changes

  - When you switch between TX & Blocks the `componentDidUpdate()` kept getting called with state changes.
