### PR TITLE
MN/POS Block Rewards Icons & Movements Page Fixes

### DIFF
--- a/client/component/Card/CardTXs.jsx
+++ b/client/component/Card/CardTXs.jsx
@@ -8,14 +8,17 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Table from '../Table';
+import TransactionValue from '../../component/Table/TransactionValue';
 
 export default class CardTXs extends Component {
   static defaultProps = {
-    txs: []
+    txs: [],
+    addBadgeClassToValue: true
   };
 
   static propTypes = {
-    txs: PropTypes.array.isRequired
+    txs: PropTypes.array.isRequired,
+    addBadgeClassToValue: PropTypes.bool
   };
 
   constructor(props) {
@@ -35,37 +38,41 @@ export default class CardTXs extends Component {
   render() {
     return (
       <Table
-        cols={ this.state.cols }
-        data={ this.props.txs.map(tx => {
+        cols={this.state.cols}
+        data={this.props.txs.map(tx => {
           const createdAt = moment(tx.createdAt).utc();
           const diffSeconds = moment().utc().diff(createdAt, 'seconds');
           let blockValue = 0.0;
           if (tx.vout && tx.vout.length) {
             tx.vout.forEach(vout => blockValue += vout.value);
           }
+          let spanClassName = ``;
+          if (this.props.addBadgeClassToValue) {
+            spanClassName = `badge badge-${blockValue < 0 ? 'danger' : 'success'}`;
+          }
 
           return ({
             ...tx,
-            age: diffSeconds < 60 ? `${ diffSeconds } seconds` : createdAt.fromNow(true),
+            age: diffSeconds < 60 ? `${diffSeconds} seconds` : createdAt.fromNow(true),
             blockHeight: (
-              <Link to={ `/block/${ tx.blockHeight }` }>
-                { tx.blockHeight }
+              <Link to={`/block/${tx.blockHeight}`}>
+                {tx.blockHeight}
               </Link>
             ),
             createdAt: dateFormat(tx.createdAt),
             recipients: tx.vout.length,
             txId: (
-              <Link to={ `/tx/${ tx.txId }` }>
-                { tx.txId }
+              <Link to={`/tx/${tx.txId}`}>
+                {tx.txId}
               </Link>
             ),
             vout: (
-              <span className={ `badge badge-${ blockValue < 0 ? 'danger' : 'success' }` }>
-                { numeral(blockValue).format('0,0.0000') }
+              <span className={spanClassName}>
+                {TransactionValue(tx, blockValue)}
               </span>
             )
           });
-        }) } />
+        })} />
     );
   };
 }

--- a/client/component/Table/TransactionValue.jsx
+++ b/client/component/Table/TransactionValue.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import numeral from 'numeral';
+import Icon from '../Icon';
+
+/**
+ * Adds ability to format a transaction value
+ */
+const TransactionValue = (tx, blockValue) => {
+  const formattedBlockValue = (numeral(blockValue).format('0,0.0000'));
+
+  if (tx.isReward) {
+    return (
+      <span title="Block Reward for POS & Masternode">
+        {formattedBlockValue}
+        <Icon name="gem" className="far pl-1 text-primary" />
+      </span>
+    );
+  }
+
+  return formattedBlockValue;
+}
+
+export default TransactionValue;

--- a/client/container/Movement.jsx
+++ b/client/container/Movement.jsx
@@ -84,22 +84,22 @@ class Movement extends Component {
 
     const select = (
       <Select
-        onChange={ value => this.handleSize(value) }
-        selectedValue={ this.state.size }
-        options={ selectOptions } />
+        onChange={value => this.handleSize(value)}
+        selectedValue={this.state.size}
+        options={selectOptions} />
     );
 
     return (
       <div>
         <HorizontalRule
-          select={ select }
+          select={select}
           title="Movement" />
-        <CardTXs txs={ this.state.txs } />
+        <CardTXs txs={this.state.txs} addBadgeClassToValue={false} />
         <Pagination
-          current={ this.state.page }
+          current={this.state.page}
           className="float-right"
-          onPage={ this.handlePage }
-          total={ this.state.pages } />
+          onPage={this.handlePage}
+          total={this.state.pages} />
         <div className="clearfix" />
       </div>
     );

--- a/client/container/Overview.jsx
+++ b/client/container/Overview.jsx
@@ -11,6 +11,7 @@ import React from 'react';
 
 import HorizontalRule from '../component/HorizontalRule';
 import Table from '../component/Table';
+import TransactionValue from '../component/Table/TransactionValue';
 
 class Overview extends Component {
   static propTypes = {
@@ -49,7 +50,7 @@ class Overview extends Component {
         createdAt: dateFormat(tx.createdAt),
         recipients: tx.vout.length,
         txId: (<Link to={ `/tx/${ tx.txId }` }>{ tx.txId }</Link>),
-        vout: numeral(blockValue).format('0,0.0000')
+        vout: TransactionValue(tx, blockValue)
       });
     });
 

--- a/config.template.js
+++ b/config.template.js
@@ -9,19 +9,12 @@ const config = {
     'prefix': '/api',
     'timeout': '5s'
   },
-  coinMarketCap: {
-    'api': 'http://api.coinmarketcap.com/v1/ticker/',
-    'ticker': 'bulwark'
-  },
   db: {
     'host': '127.0.0.1',
     'port': '27017',
     'name': 'blockex',
     'user': 'blockexuser',
     'pass': 'Explorer!1'
-  },
-  freegeoip: {
-    'api': 'https://extreme-ip-lookup.com/json/'
   },
   rpc: {
     'host': '127.0.0.1',
@@ -30,12 +23,28 @@ const config = {
     'pass': 'someverysafepassword',
     'timeout': 8000, // 8 seconds
   },
+  splitRewardsData: true, // If set to true extract out POS & MN Rewards into their own tables for additional explorer functionality
+
+  ///////////////////////////////
+  // API & Social configurations
+  ///////////////////////////////
+  freegeoip: {
+    'api': 'https://extreme-ip-lookup.com/json/'
+  },
+  coinMarketCap: {
+    'api': 'http://api.coinmarketcap.com/v1/ticker/',
+    'ticker': 'bulwark'
+  },
   slack: {
     'url': 'https://hooks.slack.com/services/A00000000/B00000000/somekindofhashhere',
     //'channel': '#general',
     //'username': 'Block Report',
     //'icon_emoji': ':bwk:'
   },
+
+  ///////////////////////////////
+  /// Community & Address Related
+  ///////////////////////////////
   community: {
     highlightedAddresses: [
       // If you comment out all of these addresses the "Community Addresses" section will not show up on the homepage. You can add as many addresses to highlight as you wish.

--- a/config.template.js
+++ b/config.template.js
@@ -23,7 +23,7 @@ const config = {
     'pass': 'someverysafepassword',
     'timeout': 8000, // 8 seconds
   },
-  splitRewardsData: true, // If set to true extract out POS & MN Rewards into their own tables for additional explorer functionality
+  splitRewardsData: false, //@plannedFeature If set to true extract out POS & MN Rewards into their own tables for additional explorer functionality (Setting to true now will not do anything)
 
   ///////////////////////////////
   // API & Social configurations

--- a/cron/util.js
+++ b/cron/util.js
@@ -1,6 +1,7 @@
 
 require('babel-polyfill');
 const { rpc } = require('../lib/cron');
+const blockchain = require('../lib/blockchain');
 const TX = require('../model/tx');
 const UTXO = require('../model/utxo');
 
@@ -102,6 +103,9 @@ async function addPoS(block, rpctx) {
   const txin = await vin(rpctx);
   const txout = await vout(rpctx, block.height);
 
+  // Give an ability for explorer to identify POS/MN rewards
+  const isRewardRawTransaction = blockchain.isRewardRawTransaction(rpctx);
+
   await TX.create({
     _id: rpctx.txid,
     blockHash: block.hash,
@@ -110,7 +114,8 @@ async function addPoS(block, rpctx) {
     txId: rpctx.txid,
     version: rpctx.version,
     vin: txin,
-    vout: txout
+    vout: txout,
+    isReward: isRewardRawTransaction
   });
 }
 

--- a/cron/util.js
+++ b/cron/util.js
@@ -138,8 +138,21 @@ async function addPoW(block, rpctx) {
 /**
  * Will process the tx from the node and return.
  * @param {String} tx The transaction hash string.
+ * @param {Boolean} verbose     (bool, optional, default=false) If false, return a string, otherwise return a json object 
  */
-async function getTX(txhash) {
+async function getTX(txhash, verbose = false) {
+  if (verbose) {
+    const rawTransactionDetails = await rpc.call('getrawtransaction', [txhash, 1]);
+    const hex = rawTransactionDetails.hex;
+    let rawTransaction = await rpc.call('decoderawtransaction', [hex]);
+
+    // We'll add some extra metadata to our transaction results (copy over confirmations, time & blocktime)
+    rawTransaction.confirmations = rawTransactionDetails.confirmations;
+    rawTransaction.time = rawTransactionDetails.time;
+    rawTransaction.blocktime = rawTransactionDetails.blocktime;
+
+    return rawTransaction;
+  }
   const hex = await rpc.call('getrawtransaction', [txhash]);
   return await rpc.call('decoderawtransaction', [hex]);
 }

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -57,177 +57,177 @@ const getMNSubsidy = (nHeight = 0, nMasternodeCount = 0, nMoneySupply = 0) => {
       ret = 0;
     } else {
       if (mNodeCoins <= (nMoneySupply * 0.01) && mNodeCoins > 0) {
-          ret = blockValue * 0.90;
+        ret = blockValue * 0.90;
       } else if (mNodeCoins <= (nMoneySupply * 0.02) && mNodeCoins > (nMoneySupply * 0.01)) {
-          ret = blockValue * 0.88;
+        ret = blockValue * 0.88;
       } else if (mNodeCoins <= (nMoneySupply * 0.03) && mNodeCoins > (nMoneySupply * 0.02)) {
-          ret = blockValue * 0.87;
+        ret = blockValue * 0.87;
       } else if (mNodeCoins <= (nMoneySupply * 0.04) && mNodeCoins > (nMoneySupply * 0.03)) {
-          ret = blockValue * 0.86;
+        ret = blockValue * 0.86;
       } else if (mNodeCoins <= (nMoneySupply * 0.05) && mNodeCoins > (nMoneySupply * 0.04)) {
-          ret = blockValue * 0.85;
+        ret = blockValue * 0.85;
       } else if (mNodeCoins <= (nMoneySupply * 0.06) && mNodeCoins > (nMoneySupply * 0.05)) {
-          ret = blockValue * 0.84;
+        ret = blockValue * 0.84;
       } else if (mNodeCoins <= (nMoneySupply * 0.07) && mNodeCoins > (nMoneySupply * 0.06)) {
-          ret = blockValue * 0.83;
+        ret = blockValue * 0.83;
       } else if (mNodeCoins <= (nMoneySupply * 0.08) && mNodeCoins > (nMoneySupply * 0.07)) {
-          ret = blockValue * 0.82;
+        ret = blockValue * 0.82;
       } else if (mNodeCoins <= (nMoneySupply * 0.09) && mNodeCoins > (nMoneySupply * 0.08)) {
-          ret = blockValue * 0.81;
+        ret = blockValue * 0.81;
       } else if (mNodeCoins <= (nMoneySupply * 0.10) && mNodeCoins > (nMoneySupply * 0.09)) {
-          ret = blockValue * 0.80;
+        ret = blockValue * 0.80;
       } else if (mNodeCoins <= (nMoneySupply * 0.11) && mNodeCoins > (nMoneySupply * 0.10)) {
-          ret = blockValue * 0.79;
+        ret = blockValue * 0.79;
       } else if (mNodeCoins <= (nMoneySupply * 0.12) && mNodeCoins > (nMoneySupply * 0.11)) {
-          ret = blockValue * 0.78;
+        ret = blockValue * 0.78;
       } else if (mNodeCoins <= (nMoneySupply * 0.13) && mNodeCoins > (nMoneySupply * 0.12)) {
-          ret = blockValue * 0.77;
+        ret = blockValue * 0.77;
       } else if (mNodeCoins <= (nMoneySupply * 0.14) && mNodeCoins > (nMoneySupply * 0.13)) {
-          ret = blockValue * 0.76;
+        ret = blockValue * 0.76;
       } else if (mNodeCoins <= (nMoneySupply * 0.15) && mNodeCoins > (nMoneySupply * 0.14)) {
-          ret = blockValue * 0.75;
+        ret = blockValue * 0.75;
       } else if (mNodeCoins <= (nMoneySupply * 0.16) && mNodeCoins > (nMoneySupply * 0.15)) {
-          ret = blockValue * 0.74;
+        ret = blockValue * 0.74;
       } else if (mNodeCoins <= (nMoneySupply * 0.17) && mNodeCoins > (nMoneySupply * 0.16)) {
-          ret = blockValue * 0.73;
+        ret = blockValue * 0.73;
       } else if (mNodeCoins <= (nMoneySupply * 0.18) && mNodeCoins > (nMoneySupply * 0.17)) {
-          ret = blockValue * 0.72;
+        ret = blockValue * 0.72;
       } else if (mNodeCoins <= (nMoneySupply * 0.19) && mNodeCoins > (nMoneySupply * 0.18)) {
-          ret = blockValue * 0.71;
+        ret = blockValue * 0.71;
       } else if (mNodeCoins <= (nMoneySupply * 0.20) && mNodeCoins > (nMoneySupply * 0.19)) {
-          ret = blockValue * 0.70;
+        ret = blockValue * 0.70;
       } else if (mNodeCoins <= (nMoneySupply * 0.21) && mNodeCoins > (nMoneySupply * 0.20)) {
-          ret = blockValue * 0.69;
+        ret = blockValue * 0.69;
       } else if (mNodeCoins <= (nMoneySupply * 0.22) && mNodeCoins > (nMoneySupply * 0.21)) {
-          ret = blockValue * 0.68;
+        ret = blockValue * 0.68;
       } else if (mNodeCoins <= (nMoneySupply * 0.23) && mNodeCoins > (nMoneySupply * 0.22)) {
-          ret = blockValue * 0.67;
+        ret = blockValue * 0.67;
       } else if (mNodeCoins <= (nMoneySupply * 0.24) && mNodeCoins > (nMoneySupply * 0.23)) {
-          ret = blockValue * 0.66;
+        ret = blockValue * 0.66;
       } else if (mNodeCoins <= (nMoneySupply * 0.25) && mNodeCoins > (nMoneySupply * 0.24)) {
-          ret = blockValue * 0.65;
+        ret = blockValue * 0.65;
       } else if (mNodeCoins <= (nMoneySupply * 0.26) && mNodeCoins > (nMoneySupply * 0.25)) {
-          ret = blockValue * 0.64;
+        ret = blockValue * 0.64;
       } else if (mNodeCoins <= (nMoneySupply * 0.27) && mNodeCoins > (nMoneySupply * 0.26)) {
-          ret = blockValue * 0.63;
+        ret = blockValue * 0.63;
       } else if (mNodeCoins <= (nMoneySupply * 0.28) && mNodeCoins > (nMoneySupply * 0.27)) {
-          ret = blockValue * 0.62;
+        ret = blockValue * 0.62;
       } else if (mNodeCoins <= (nMoneySupply * 0.29) && mNodeCoins > (nMoneySupply * 0.28)) {
-          ret = blockValue * 0.61;
+        ret = blockValue * 0.61;
       } else if (mNodeCoins <= (nMoneySupply * 0.30) && mNodeCoins > (nMoneySupply * 0.29)) {
-          ret = blockValue * 0.60;
+        ret = blockValue * 0.60;
       } else if (mNodeCoins <= (nMoneySupply * 0.31) && mNodeCoins > (nMoneySupply * 0.30)) {
-          ret = blockValue * 0.59;
+        ret = blockValue * 0.59;
       } else if (mNodeCoins <= (nMoneySupply * 0.32) && mNodeCoins > (nMoneySupply * 0.31)) {
-          ret = blockValue * 0.58;
+        ret = blockValue * 0.58;
       } else if (mNodeCoins <= (nMoneySupply * 0.33) && mNodeCoins > (nMoneySupply * 0.32)) {
-          ret = blockValue * 0.57;
+        ret = blockValue * 0.57;
       } else if (mNodeCoins <= (nMoneySupply * 0.34) && mNodeCoins > (nMoneySupply * 0.33)) {
-          ret = blockValue * 0.56;
+        ret = blockValue * 0.56;
       } else if (mNodeCoins <= (nMoneySupply * 0.35) && mNodeCoins > (nMoneySupply * 0.34)) {
-          ret = blockValue * 0.55;
+        ret = blockValue * 0.55;
       } else if (mNodeCoins <= (nMoneySupply * 0.363) && mNodeCoins > (nMoneySupply * 0.35)) {
-          ret = blockValue * 0.54;
+        ret = blockValue * 0.54;
       } else if (mNodeCoins <= (nMoneySupply * 0.376) && mNodeCoins > (nMoneySupply * 0.363)) {
-          ret = blockValue * 0.53;
+        ret = blockValue * 0.53;
       } else if (mNodeCoins <= (nMoneySupply * 0.389) && mNodeCoins > (nMoneySupply * 0.376)) {
-          ret = blockValue * 0.52;
+        ret = blockValue * 0.52;
       } else if (mNodeCoins <= (nMoneySupply * 0.402) && mNodeCoins > (nMoneySupply * 0.389)) {
-          ret = blockValue * 0.51;
+        ret = blockValue * 0.51;
       } else if (mNodeCoins <= (nMoneySupply * 0.415) && mNodeCoins > (nMoneySupply * 0.402)) {
-          ret = blockValue * 0.50;
+        ret = blockValue * 0.50;
       } else if (mNodeCoins <= (nMoneySupply * 0.428) && mNodeCoins > (nMoneySupply * 0.415)) {
-          ret = blockValue * 0.49;
+        ret = blockValue * 0.49;
       } else if (mNodeCoins <= (nMoneySupply * 0.441) && mNodeCoins > (nMoneySupply * 0.428)) {
-          ret = blockValue * 0.48;
+        ret = blockValue * 0.48;
       } else if (mNodeCoins <= (nMoneySupply * 0.454) && mNodeCoins > (nMoneySupply * 0.441)) {
-          ret = blockValue * 0.47;
+        ret = blockValue * 0.47;
       } else if (mNodeCoins <= (nMoneySupply * 0.467) && mNodeCoins > (nMoneySupply * 0.454)) {
-          ret = blockValue * 0.46;
+        ret = blockValue * 0.46;
       } else if (mNodeCoins <= (nMoneySupply * 0.48) && mNodeCoins > (nMoneySupply * 0.467)) {
-          ret = blockValue * 0.45;
+        ret = blockValue * 0.45;
       } else if (mNodeCoins <= (nMoneySupply * 0.493) && mNodeCoins > (nMoneySupply * 0.48)) {
-          ret = blockValue * 0.44;
+        ret = blockValue * 0.44;
       } else if (mNodeCoins <= (nMoneySupply * 0.506) && mNodeCoins > (nMoneySupply * 0.493)) {
-          ret = blockValue * 0.43;
+        ret = blockValue * 0.43;
       } else if (mNodeCoins <= (nMoneySupply * 0.519) && mNodeCoins > (nMoneySupply * 0.506)) {
-          ret = blockValue * 0.42;
+        ret = blockValue * 0.42;
       } else if (mNodeCoins <= (nMoneySupply * 0.532) && mNodeCoins > (nMoneySupply * 0.519)) {
-          ret = blockValue * 0.41;
+        ret = blockValue * 0.41;
       } else if (mNodeCoins <= (nMoneySupply * 0.545) && mNodeCoins > (nMoneySupply * 0.532)) {
-          ret = blockValue * 0.40;
+        ret = blockValue * 0.40;
       } else if (mNodeCoins <= (nMoneySupply * 0.558) && mNodeCoins > (nMoneySupply * 0.545)) {
-          ret = blockValue * 0.39;
+        ret = blockValue * 0.39;
       } else if (mNodeCoins <= (nMoneySupply * 0.571) && mNodeCoins > (nMoneySupply * 0.558)) {
-          ret = blockValue * 0.38;
+        ret = blockValue * 0.38;
       } else if (mNodeCoins <= (nMoneySupply * 0.584) && mNodeCoins > (nMoneySupply * 0.571)) {
-          ret = blockValue * 0.37;
+        ret = blockValue * 0.37;
       } else if (mNodeCoins <= (nMoneySupply * 0.597) && mNodeCoins > (nMoneySupply * 0.584)) {
-          ret = blockValue * 0.36;
+        ret = blockValue * 0.36;
       } else if (mNodeCoins <= (nMoneySupply * 0.61) && mNodeCoins > (nMoneySupply * 0.597)) {
-          ret = blockValue * 0.35;
+        ret = blockValue * 0.35;
       } else if (mNodeCoins <= (nMoneySupply * 0.623) && mNodeCoins > (nMoneySupply * 0.61)) {
-          ret = blockValue * 0.34;
+        ret = blockValue * 0.34;
       } else if (mNodeCoins <= (nMoneySupply * 0.636) && mNodeCoins > (nMoneySupply * 0.623)) {
-          ret = blockValue * 0.33;
+        ret = blockValue * 0.33;
       } else if (mNodeCoins <= (nMoneySupply * 0.649) && mNodeCoins > (nMoneySupply * 0.636)) {
-          ret = blockValue * 0.32;
+        ret = blockValue * 0.32;
       } else if (mNodeCoins <= (nMoneySupply * 0.662) && mNodeCoins > (nMoneySupply * 0.649)) {
-          ret = blockValue * 0.31;
+        ret = blockValue * 0.31;
       } else if (mNodeCoins <= (nMoneySupply * 0.675) && mNodeCoins > (nMoneySupply * 0.662)) {
-          ret = blockValue * 0.30;
+        ret = blockValue * 0.30;
       } else if (mNodeCoins <= (nMoneySupply * 0.688) && mNodeCoins > (nMoneySupply * 0.675)) {
-          ret = blockValue * 0.29;
+        ret = blockValue * 0.29;
       } else if (mNodeCoins <= (nMoneySupply * 0.701) && mNodeCoins > (nMoneySupply * 0.688)) {
-          ret = blockValue * 0.28;
+        ret = blockValue * 0.28;
       } else if (mNodeCoins <= (nMoneySupply * 0.714) && mNodeCoins > (nMoneySupply * 0.701)) {
-          ret = blockValue * 0.27;
+        ret = blockValue * 0.27;
       } else if (mNodeCoins <= (nMoneySupply * 0.727) && mNodeCoins > (nMoneySupply * 0.714)) {
-          ret = blockValue * 0.26;
+        ret = blockValue * 0.26;
       } else if (mNodeCoins <= (nMoneySupply * 0.74) && mNodeCoins > (nMoneySupply * 0.727)) {
-          ret = blockValue * 0.25;
+        ret = blockValue * 0.25;
       } else if (mNodeCoins <= (nMoneySupply * 0.753) && mNodeCoins > (nMoneySupply * 0.74)) {
-          ret = blockValue * 0.24;
+        ret = blockValue * 0.24;
       } else if (mNodeCoins <= (nMoneySupply * 0.766) && mNodeCoins > (nMoneySupply * 0.753)) {
-          ret = blockValue * 0.23;
+        ret = blockValue * 0.23;
       } else if (mNodeCoins <= (nMoneySupply * 0.779) && mNodeCoins > (nMoneySupply * 0.766)) {
-          ret = blockValue * 0.22;
+        ret = blockValue * 0.22;
       } else if (mNodeCoins <= (nMoneySupply * 0.792) && mNodeCoins > (nMoneySupply * 0.779)) {
-          ret = blockValue * 0.21;
+        ret = blockValue * 0.21;
       } else if (mNodeCoins <= (nMoneySupply * 0.805) && mNodeCoins > (nMoneySupply * 0.792)) {
-          ret = blockValue * 0.20;
+        ret = blockValue * 0.20;
       } else if (mNodeCoins <= (nMoneySupply * 0.818) && mNodeCoins > (nMoneySupply * 0.805)) {
-          ret = blockValue * 0.19;
+        ret = blockValue * 0.19;
       } else if (mNodeCoins <= (nMoneySupply * 0.831) && mNodeCoins > (nMoneySupply * 0.818)) {
-          ret = blockValue * 0.18;
+        ret = blockValue * 0.18;
       } else if (mNodeCoins <= (nMoneySupply * 0.844) && mNodeCoins > (nMoneySupply * 0.831)) {
-          ret = blockValue * 0.17;
+        ret = blockValue * 0.17;
       } else if (mNodeCoins <= (nMoneySupply * 0.857) && mNodeCoins > (nMoneySupply * 0.844)) {
-          ret = blockValue * 0.16;
+        ret = blockValue * 0.16;
       } else if (mNodeCoins <= (nMoneySupply * 0.87) && mNodeCoins > (nMoneySupply * 0.857)) {
-          ret = blockValue * 0.15;
+        ret = blockValue * 0.15;
       } else if (mNodeCoins <= (nMoneySupply * 0.883) && mNodeCoins > (nMoneySupply * 0.87)) {
-          ret = blockValue * 0.14;
+        ret = blockValue * 0.14;
       } else if (mNodeCoins <= (nMoneySupply * 0.896) && mNodeCoins > (nMoneySupply * 0.883)) {
-          ret = blockValue * 0.13;
+        ret = blockValue * 0.13;
       } else if (mNodeCoins <= (nMoneySupply * 0.909) && mNodeCoins > (nMoneySupply * 0.896)) {
-          ret = blockValue * 0.12;
+        ret = blockValue * 0.12;
       } else if (mNodeCoins <= (nMoneySupply * 0.922) && mNodeCoins > (nMoneySupply * 0.909)) {
-          ret = blockValue * 0.11;
+        ret = blockValue * 0.11;
       } else if (mNodeCoins <= (nMoneySupply * 0.935) && mNodeCoins > (nMoneySupply * 0.922)) {
-          ret = blockValue * 0.10;
+        ret = blockValue * 0.10;
       } else if (mNodeCoins <= (nMoneySupply * 0.945) && mNodeCoins > (nMoneySupply * 0.935)) {
-          ret = blockValue * 0.09;
+        ret = blockValue * 0.09;
       } else if (mNodeCoins <= (nMoneySupply * 0.961) && mNodeCoins > (nMoneySupply * 0.945)) {
-          ret = blockValue * 0.08;
+        ret = blockValue * 0.08;
       } else if (mNodeCoins <= (nMoneySupply * 0.974) && mNodeCoins > (nMoneySupply * 0.961)) {
-          ret = blockValue * 0.07;
+        ret = blockValue * 0.07;
       } else if (mNodeCoins <= (nMoneySupply * 0.987) && mNodeCoins > (nMoneySupply * 0.974)) {
-          ret = blockValue * 0.06;
+        ret = blockValue * 0.06;
       } else if (mNodeCoins <= (nMoneySupply * 0.99) && mNodeCoins > (nMoneySupply * 0.987)) {
-          ret = blockValue * 0.05;
+        ret = blockValue * 0.05;
       } else {
-          ret = blockValue * 0.01;
+        ret = blockValue * 0.01;
       }
     }
   }
@@ -256,7 +256,7 @@ const getSubsidy = (nHeight = 1) => {
   } else if (nHeight <= 345600 && nHeight >= 259200) {
     nSubsidy = 31.25;
 
-  // POS Year 1
+    // POS Year 1
   } else if (nHeight <= 431999 && nHeight > 345600) {
     nSubsidy = 25;
   } else if (nHeight <= 518399 && nHeight >= 432000) {
@@ -266,7 +266,7 @@ const getSubsidy = (nHeight = 1) => {
   } else if (nHeight <= 691199 && nHeight >= 604800) {
     nSubsidy = 15.625;
 
-  // POS Year 2
+    // POS Year 2
   } else if (nHeight <= 777599 && nHeight >= 691200) {
     nSubsidy = 12.50;
   } else if (nHeight <= 863999 && nHeight >= 777600) {
@@ -276,7 +276,7 @@ const getSubsidy = (nHeight = 1) => {
   } else if (nHeight <= 1036799 && nHeight >= 950400) {
     nSubsidy = 7.812;
 
-  // POS Year 3
+    // POS Year 3
   } else if (nHeight <= 1123199 && nHeight >= 1036800) {
     nSubsidy = 6.250;
   } else if (nHeight <= 1209599 && nHeight >= 1123200) {
@@ -286,7 +286,7 @@ const getSubsidy = (nHeight = 1) => {
   } else if (nHeight <= 1382399 && nHeight >= 1296000) {
     nSubsidy = 3.906;
 
-  // POS Year 4
+    // POS Year 4
   } else if (nHeight <= 1468799 && nHeight >= 1382400) {
     nSubsidy = 3.125;
   } else if (nHeight <= 1555199 && nHeight >= 1468800) {
@@ -310,11 +310,11 @@ const getROI = (subsidy, mns) => {
 };
 
 const isAddress = (s) => {
-  return typeof(s) === 'string' && s.length === 34;
+  return typeof (s) === 'string' && s.length === 34;
 };
 
 const isBlock = (s) => {
-  return !isNaN(s) || (typeof(s) === 'string');
+  return !isNaN(s) || (typeof (s) === 'string');
 };
 
 const isPoS = (b) => {
@@ -322,8 +322,23 @@ const isPoS = (b) => {
 };
 
 const isTX = (s) => {
-  return typeof(s) === 'string' && s.length === 64;
+  return typeof (s) === 'string' && s.length === 64;
 };
+
+/**
+ * How we identify if a raw transaction is Proof Of Stake & Masternode reward
+ * @param {String} rpctx The transaction hash string.
+ */
+const isRewardRawTransaction = (rpctx) => {
+  return rpctx.vin.length == 1 &&
+    rpctx.vout.length == 3 &&
+    // First vout is always in this format
+    rpctx.vout[0].value == 0.0 &&
+    rpctx.vout[0].n == 0 &&
+    rpctx.vout[0].scriptPubKey &&
+    rpctx.vout[0].scriptPubKey.type == "nonstandard";
+
+}
 
 module.exports = {
   avgBlockTime,
@@ -343,5 +358,6 @@ module.exports = {
   isAddress,
   isBlock,
   isPoS,
-  isTX
+  isTX,
+  isRewardRawTransaction
 };

--- a/model/tx.js
+++ b/model/tx.js
@@ -38,7 +38,8 @@ const txSchema = new mongoose.Schema({
   txId: { index: true, required: true, type: String },
   version: { required: true, type: Number },
   vin: { required: true, type: [TXIn] },
-  vout: { required: true, type: [TXOut] }
+  vout: { required: true, type: [TXOut] },
+  isReward: { required: false, type: Boolean }
 }, { versionKey: false });
 
 /**


### PR DESCRIPTION
## Proposed Changes

  - Split out value into Transaction Value component so we can style it. I use this for adding MN/POS icon
  - `getTX()` now has optional verboisty. We will use this to get confirmations on transactions
  - Updated config to include future option
  - New util method `isRewardRawTransaction()` helps identify if TX is MN/POS Block Reward
