### PR TITLE
Removed old dequeue algorithm, replaced with throttling instead

### DIFF
--- a/client/container/TX.jsx
+++ b/client/container/TX.jsx
@@ -20,7 +20,7 @@ class TX extends Component {
 
     // Props from mapState() below (only if available)
     txFromStore: PropTypes.object,
-    blockHeight: PropTypes.number.isRequired
+    latestTx: PropTypes.object
   };
 
   constructor(props) {
@@ -28,8 +28,7 @@ class TX extends Component {
     this.state = {
       error: null,
       loading: true,
-      tx: null,
-      blockHeight: props.blockHeight
+      tx: null
     };
   };
 
@@ -46,10 +45,11 @@ class TX extends Component {
   }
 
   getTransactionInfo() {
+    const blockHeight = this.props.latestTx ? this.props.latestTx.blockHeight : 0; // Take first TX from store (this will have latest blockHeight as they're ordred by blockHeight descending);
     return (
       <div>
         <HorizontalRule title="Transaction Info" />
-        <CardTX height={this.state.blockHeight} tx={this.state.tx} />
+        <CardTX height={blockHeight} tx={this.state.tx} />
       </div>
     );
   }
@@ -148,10 +148,11 @@ const mapDispatch = dispatch => ({
 const mapState = (state, ownProps) => {
   // Try to fetch transaction from store, if it exists we don't need to reload it
   const txForHashFromStore = state.txs.find(tx => tx.txId == ownProps.match.params.hash);
+  const latestTx = state.txs.length > 0 ? state.txs[0] : null; // fetch most recent block from store (if there is one)
 
   return {
     txFromStore: txForHashFromStore,
-    blockHeight: state.txs.length > 0 ? state.txs[0].blockHeight : 0 // Take first TX from store (this will have latest blockHeight as they're ordred by blockHeight descending)
+    latestTx: latestTx
   };
 };
 

--- a/lib/debounce.js
+++ b/lib/debounce.js
@@ -1,0 +1,30 @@
+/**
+ * This takes the usual debounce and adds immediate callback. 
+ * @param {Function} callback What function to call after waitMs elapsed
+ * @param {Number} waitMs How many miliseconds to wait (60 = 1 minute)
+ * @param {Boolean} isImmediate If isImmediate is true, The initial request would execute the callback instnaly. All other calls would have the expected delay
+ */
+const debounce = (callback, waitMs, isImmediate = false) => {
+  let timeout;
+  let isFired = false;
+  return (...args) => {
+    const context = this;
+    clearTimeout(timeout);
+
+    const callbackWrapper = () => {
+      isFired = true;
+      clearTimeout(timeout);
+      callback.apply(context, args);
+    };
+
+    if (isImmediate && !isFired) {
+      callbackWrapper();
+      return;
+    }
+
+    timeout = setTimeout(callbackWrapper, waitMs);
+    return timeout;
+  };
+}
+
+module.exports = debounce;

--- a/lib/throttle.js
+++ b/lib/throttle.js
@@ -1,11 +1,35 @@
-import debounce from './debounce'
-
 /**
- * This takes the usual debounce and adds immediate callback. 
+ * Throttle how often a callback can be executed consecutively
  * @param {Function} callback What function to call after waitMs elapsed
  * @param {Number} waitMs How many miliseconds to wait (60 = 1 minute)
  */
 const throttle = (callback, waitMs) => {
-  return debounce(callback, waitMs, true);
+  let timeout;
+  let canFireInstantly = true;
+  let shouldFire = true;
+
+  return (...args) => {
+    const context = this;
+    clearTimeout(timeout);
+    shouldFire = true;
+
+    const callbackWrapper = () => {
+      canFireInstantly = true;
+      if (shouldFire) {
+        callback.apply(context, args);
+      }
+    };
+
+    if (canFireInstantly) {
+      callback.apply(context, args);
+      shouldFire = false;
+      canFireInstantly = false;
+      clearTimeout(timeout);
+    }
+
+    timeout = setTimeout(callbackWrapper, waitMs);
+    return timeout;
+  };
 }
+
 module.exports = throttle;

--- a/lib/throttle.js
+++ b/lib/throttle.js
@@ -1,0 +1,11 @@
+import debounce from './debounce'
+
+/**
+ * This takes the usual debounce and adds immediate callback. 
+ * @param {Function} callback What function to call after waitMs elapsed
+ * @param {Number} waitMs How many miliseconds to wait (60 = 1 minute)
+ */
+const throttle = (callback, waitMs) => {
+  return debounce(callback, waitMs, true);
+}
+module.exports = throttle;


### PR DESCRIPTION
## Proposed Changes

Old dequeue approach was using an old & outdated approach. Plus it would cause all masternode & movement page views to have unnnecessary 800ms of waiting time on each request. Throttling handles this in a much better way.

Also fixed confirmations not updating in realtime.