### PR TITLE
New Restaking Indicator & Tweaks

### DIFF
--- a/client/component/Card/CardBlockRewardDetailsStaking.jsx
+++ b/client/component/Card/CardBlockRewardDetailsStaking.jsx
@@ -5,11 +5,27 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import config from '../../../config'
 import PosProfitabilityScore from '../PosProfitabilityScore'
+import PosRestakeIndicator from '../../component/FormattedValues/PosRestakeIndicator'
 
 export default class CardBlockRewardDetailsStaking extends Component {
   static propTypes = {
     tx: PropTypes.object.isRequired
   };
+  
+  getBlockRewardLink(reward) {
+    const posRestakeIndicator = <PosRestakeIndicator reward={reward} includeShortName={true} />;
+    
+    // Link to the previous stake if this is a restake
+    if (reward.stake.input.isRestake) {
+      return (
+        <Link to={`/tx/${reward.stake.input.txId}`}>
+          {posRestakeIndicator}
+        </Link>
+      );
+    }
+
+    return posRestakeIndicator;
+  }
 
   render() {
     // Ensure this reward transaction has new blockRewardDetails data (for backwards compatability)
@@ -31,7 +47,9 @@ export default class CardBlockRewardDetailsStaking extends Component {
           </div>
           <div className="card__row">
             <span className="card__label">Stake Reward:</span>
-            <span className="card__result">{numeral(blockRewardDetails.stake.reward).format(config.coinDetails.coinNumberFormat)} {config.coinDetails.shortName}</span>
+            <span className="card__result">
+              {this.getBlockRewardLink(blockRewardDetails)}
+            </span>
           </div>
           <div className="card__row">
             <span className="card__label">Stake Input Age:</span>

--- a/client/component/Card/CardRewards.jsx
+++ b/client/component/Card/CardRewards.jsx
@@ -7,6 +7,7 @@ import numeral from 'numeral';
 import PropTypes from 'prop-types';
 import React from 'react';
 import config from '../../../config'
+import Icon from '../Icon'
 
 import Table from '../Table';
 import PosProfitabilityScore from '../PosProfitabilityScore';
@@ -28,7 +29,7 @@ export default class CardRewards extends Component {
     this.state = {
       cols: [
         { key: 'blockHeight', title: 'Block #' },
-        { key: 'posInputSizeAddress', title: 'Input Size' },
+        { key: 'posInputSize', title: 'Input Size' },
         { key: 'posInputConfirmations', title: 'Confirmations' },
         { key: 'computedProfitabilityScore', title: 'POS Profitability Score' },
         { key: 'date', title: 'Created' },
@@ -46,6 +47,28 @@ export default class CardRewards extends Component {
     return amountFormatted;
   }
 
+  getRestakeIcon(reward) {
+    if (!reward.stake.input.isRestake) {
+      return null;
+    }
+    return <Icon name="recycle" className="fas pl-1 text-primary" />;
+  }
+  getRewardLink(reward) {
+    // By default go to the tx that was stake's input
+    let txId = reward.stake.input.txId;
+    // In update, we now can go directly to reward tx
+    if (reward.txId) {
+      txId = reward.txId;
+    }
+
+    return `/tx/${txId}`;
+  }
+  getTitle(reward) {
+    if (!reward.stake.input.isRestake) {
+      return null;
+    }
+    return "Restake (Stake of Previously Staked Output)";
+  }
 
   getTableData() {
     return this.props.rewards.map(reward => {
@@ -55,27 +78,29 @@ export default class CardRewards extends Component {
       return ({
         ...reward,
         blockHeight: (
-          <Link to={`/tx/${reward.stake.input.txId}`}>
+          <Link to={this.getRewardLink(reward)}>
             {reward.blockHeight}
           </Link>
         ),
-        posInputSizeAddress: (
-          <Link to={`/tx/${reward.stake.input.txId}`}>
-            {this.formatAmount(reward.stake.input.value)}
-          </Link>
+        posInputSize: (
+          <span title={this.getTitle(reward)}>
+            <Link to={this.getRewardLink(reward)}>
+              {this.formatAmount(reward.stake.input.value)}{this.getRestakeIcon(reward)}
+            </Link>
+          </span>
         ),
         posInputConfirmations: (
-          <Link to={`/tx/${reward.stake.input.txId}`}>
+          <Link to={this.getRewardLink(reward)}>
             {reward.stake.input.confirmations}
           </Link>
         ),
         date: (
-          <Link to={`/tx/${reward.stake.input.txId}`}>
+          <Link to={this.getRewardLink(reward)}>
             {dateFormat(reward.date)} ({diffSeconds < 60 ? `${diffSeconds} seconds` : date.fromNow(true)})
           </Link>
         ),
         computedProfitabilityScore: (
-          <Link to={`/tx/${reward.stake.input.txId}`}>
+          <Link to={this.getRewardLink(reward)}>
             <PosProfitabilityScore reward={reward} />
           </Link>
         ),

--- a/client/component/Card/CardRewards.jsx
+++ b/client/component/Card/CardRewards.jsx
@@ -11,6 +11,7 @@ import Icon from '../Icon'
 
 import Table from '../Table';
 import PosProfitabilityScore from '../PosProfitabilityScore';
+import PosRestakeIndicator from '../FormattedValues/PosRestakeIndicator'
 
 export default class CardRewards extends Component {
   static defaultProps = {
@@ -47,12 +48,6 @@ export default class CardRewards extends Component {
     return amountFormatted;
   }
 
-  getRestakeIcon(reward) {
-    if (!reward.stake.input.isRestake) {
-      return null;
-    }
-    return <Icon name="recycle" className="fas pl-1 text-primary" />;
-  }
   getRewardLink(reward) {
     // By default go to the tx that was stake's input
     let txId = reward.stake.input.txId;
@@ -62,12 +57,6 @@ export default class CardRewards extends Component {
     }
 
     return `/tx/${txId}`;
-  }
-  getTitle(reward) {
-    if (!reward.stake.input.isRestake) {
-      return null;
-    }
-    return "Restake (Stake of Previously Staked Output)";
   }
 
   getTableData() {
@@ -83,11 +72,9 @@ export default class CardRewards extends Component {
           </Link>
         ),
         posInputSize: (
-          <span title={this.getTitle(reward)}>
-            <Link to={this.getRewardLink(reward)}>
-              {this.formatAmount(reward.stake.input.value)}{this.getRestakeIcon(reward)}
-            </Link>
-          </span>
+          <Link to={this.getRewardLink(reward)}>
+            <PosRestakeIndicator reward={reward} />
+          </Link>
         ),
         posInputConfirmations: (
           <Link to={this.getRewardLink(reward)}>

--- a/client/component/FormattedValues/PosRestakeIndicator.jsx
+++ b/client/component/FormattedValues/PosRestakeIndicator.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import numeral from 'numeral';
+import Icon from '../Icon';
+import config from '../../../config'
+
+/**
+ * Adds ability to format a transaction value
+ * @todo move to FormattedValues folder
+ */
+const PosRestakeIndicator = ({ reward, includeShortName = false }) => {
+
+  const getRestakeIcon = (reward) => {
+    if (!reward.stake.input.isRestake) {
+      return null;
+    }
+    return <Icon name="recycle" className="fas pl-1 text-primary" />;
+  }
+  const getTitle = (reward) => {
+    if (!reward.stake.input.isRestake) {
+      return null;
+    }
+    return "Restake (Stake of Previously Staked Output)";
+  }
+
+  const formatAmount = (amountToFormat) => {
+    const amountFormatted = (numeral(amountToFormat).format(config.coinDetails.coinNumberFormat)); //@todo We really need to move all of these formattings into a single component
+
+    if (includeShortName) {
+      return `${amountFormatted} ${config.coinDetails.shortName}`;
+    }
+
+    return amountFormatted;
+  }
+
+  return (
+    <span title={getTitle(reward)}>
+      {formatAmount(reward.stake.input.value)}{getRestakeIcon(reward)}
+    </span>
+  );
+}
+
+export default PosRestakeIndicator;

--- a/client/component/PosProfitabilityScore.jsx
+++ b/client/component/PosProfitabilityScore.jsx
@@ -22,7 +22,7 @@ const PosProfitabilityScore = ({ reward, includeTitle = true }) => {
     const profitabilityTitle = includeTitle ? profitabilityStyle.title : null;
 
     return (
-      <span class="badge" style={{ backgroundColor: profitabilityStyle.color }} title={profitabilityTitle}>
+      <span className="badge" style={{ backgroundColor: profitabilityStyle.color }} title={profitabilityTitle}>
         {profitabilityWeight.toFixed(0)}
       </span>
     );

--- a/cron/block.js
+++ b/cron/block.js
@@ -12,6 +12,7 @@ const util = require('./util');
 const Block = require('../model/block');
 const TX = require('../model/tx');
 const UTXO = require('../model/utxo');
+const BlockRewardDetails = require('../model/blockRewardDetails');
 
 /**
  * Process the blocks and transactions.
@@ -23,6 +24,7 @@ async function syncBlocks(start, stop, clean = false) {
     await Block.remove({ height: { $gte: start, $lte: stop } });
     await TX.remove({ blockHeight: { $gte: start, $lte: stop } });
     await UTXO.remove({ blockHeight: { $gte: start, $lte: stop } });
+    await BlockRewardDetails.remove({ blockHeight: { $gte: start, $lte: stop } });
   }
 
   let block;
@@ -138,7 +140,7 @@ async function update() {
     const info = await rpc.call('getinfo');
     const block = await Block.findOne().sort({ height: -1 });
 
-    let clean = true; // Always clear for now.
+    let clean = false; // We no longer need to clean by default because block is the last item inserted. If we have the block that means all data for that block exists
     let dbHeight = block && block.height ? block.height : 1;
     let rpcHeight = info.blocks;
 

--- a/cron/util.js
+++ b/cron/util.js
@@ -194,6 +194,9 @@ async function addPoS(block, rpctx) {
       const masternodeRewardAmount = rpctx.vout[2].value;
       const masternodeRewardAddress = rpctx.vout[2].scriptPubKey.addresses[0];
 
+      // Allows us to tell if we've staked on an output of a stake reward (staking a stake)
+      const isRestake = blockchain.isRewardRawTransaction(stakedInputRawTx);
+
       // Store all the block rewards in it's own indexed collection
       let blockRewardDetails = new BlockRewardDetails(
         {
@@ -201,6 +204,7 @@ async function addPoS(block, rpctx) {
           //blockHash: block.hash,
           blockHeight: block.height,
           date: block.createdAt,
+          txId: rpctx.txid,
           stake: {
             address: stakeRewardAddress,
             input: {
@@ -209,6 +213,9 @@ async function addPoS(block, rpctx) {
               confirmations: stakedInputConfirmations,
               date: new Date(stakedInputTime * 1000),
               age: currentTxTime - stakedInputTime,
+              isRestake: isRestake,
+              vinCount: rpctx.vin.length,
+              voutCount: rpctx.vout.length
             },
             reward: stakeRewardAmount
           },

--- a/model/blockRewardDetails.js
+++ b/model/blockRewardDetails.js
@@ -19,6 +19,9 @@ const BlockRewardDetailsStakeInput = new mongoose.Schema({
   confirmations: { index: true, required: true, type: Number },
   date: { index: true, required: true, type: Date },
   age: { index: true, required: true, type: Number },
+  isRestake: { index: false, required: true, type: Boolean },
+  vinCount: { index: true, required: true, type: Number },
+  voutCount: { index: true, required: true, type: Number },
 }, { _id: false, versionKey: false });
 
 /**
@@ -46,6 +49,7 @@ const BlockRewardDetails = new mongoose.Schema({
   //blockHash: { required: true, type: String },
   blockHeight: { index: true, required: true, type: Number },
   date: { index: true, required: true, type: Date },
+  txId: { index: true, required: true, type: String },
 
   stake: { index: false, required: true, type: BlockRewardDetailsStake },
   masternode: { index: false, required: true, type: BlockRewardDetailsMasternode },

--- a/server/handler/blockex.js
+++ b/server/handler/blockex.js
@@ -48,6 +48,7 @@ const getAddress = async (req, res) => {
         },
         { $sort: { blockHeight: -1 } }
       ])
+      .limit(100) //@todo Limit too 100 transactions at the moment, until we implement proper serverside pagination 
       .allowDiskUse(true)
       .exec();
     const qutxo = UTXO
@@ -55,6 +56,7 @@ const getAddress = async (req, res) => {
         { $match: { address: req.params.hash } },
         { $sort: { blockHeight: -1 } }
       ])
+      .limit(100) //@todo Limit too 100 transactions at the moment, until we implement proper serverside pagination 
       .allowDiskUse(true)
       .exec();
 


### PR DESCRIPTION
## Proposed Changes

  - Reduce address txs to 100 until we add backend pagination (some addresses were returning 30+mb of json data)
  - Added new reward details (including restaking)
  - Added restaking indicators & updated navigation between rewards
  - Cron no longer doubles up rewards & no longer requires cleaning by default
